### PR TITLE
Add audience verification via Spring Boot configuration property

### DIFF
--- a/refarch-backend/src/main/resources/application.yml
+++ b/refarch-backend/src/main/resources/application.yml
@@ -1,6 +1,14 @@
 spring:
   application.name: @project.artifactId@
   banner.location: banner.txt
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          audiences:
+          # adds audience verification - https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#_supplying_audiences
+          # TODO - should be the clientId of the actual project
+          - refarch
 
 server:
   shutdown: "graceful"


### PR DESCRIPTION
**Description**

Adds `aud` (audience) Claim verification at the backend using Spring Boot auto-configuration via configuration property `spring.security.oauth2.resourceserver.jwt.audiences` (https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#_supplying_audiences)


**Reference**

Issues #91 
