### PR TITLE
:bug: Fixed PMD configuration

### DIFF
--- a/refarch-backend/pom.xml
+++ b/refarch-backend/pom.xml
@@ -379,6 +379,11 @@
                     <minimumTokens>100</minimumTokens>
                     <targetJdk>${java.version}</targetJdk>
                     <printFailingErrors>true</printFailingErrors>
+                    <linkXRef>false</linkXRef>
+                    <excludeRoots>
+                        <excludeRoot>target/generated-sources</excludeRoot>
+                        <excludeRoot>target/generated-test-sources</excludeRoot>
+                    </excludeRoots>
                     <rulesets>
                         <ruleset>../shared-files/pmd-ruleset.xml</ruleset>
                     </rulesets>

--- a/refarch-eai/pom.xml
+++ b/refarch-eai/pom.xml
@@ -205,6 +205,11 @@
                     <minimumTokens>100</minimumTokens>
                     <targetJdk>${java.version}</targetJdk>
                     <printFailingErrors>true</printFailingErrors>
+                    <linkXRef>false</linkXRef>
+                    <excludeRoots>
+                        <excludeRoot>target/generated-sources</excludeRoot>
+                        <excludeRoot>target/generated-test-sources</excludeRoot>
+                    </excludeRoots>
                     <rulesets>
                         <ruleset>../shared-files/pmd-ruleset.xml</ruleset>
                     </rulesets>

--- a/shared-files/pmd-ruleset.xml
+++ b/shared-files/pmd-ruleset.xml
@@ -14,7 +14,9 @@
         <exclude name="ShortVariable"/>
         <exclude name="AtLeastOneConstructor"/>
     </rule>
-    <rule ref="category/java/design.xml"/>
+    <rule ref="category/java/design.xml">
+        <exclude name="LoosePackageCoupling" />
+    </rule>
     <rule ref="category/java/errorprone.xml"/>
     <rule ref="category/java/security.xml"/>
     <rule ref="category/java/multithreading.xml"/>


### PR DESCRIPTION
**Description**
- Disabled linkXRef as its only needed when generating reports in conjunction with maven-jxr-plugin
- Removed LooseCoupling rule as it requires project specific configuration
- Exluded generated sources and test-sources from analyzation

**Reference**
Issues #177
