### PR TITLE
:bug: Fix env variable to make gateway startup normally again

### DIFF
--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -112,7 +112,7 @@ services:
     - SPRING_CLOUD_GATEWAY_ROUTES_0_FILTERS_0=RewritePath=/api/sso/userinfo, /auth/realms/local_realm/protocol/openid-connect/userinfo
     - SPRING_CLOUD_GATEWAY_ROUTES_1_ID=backend
     - SPRING_CLOUD_GATEWAY_ROUTES_1_URI=http://host.docker.internal:39146/
-    - SPRING_CLOUD_GATEWAY_ROUTES_1_PREDICATES_0=/api/backend-service/**
+    - SPRING_CLOUD_GATEWAY_ROUTES_1_PREDICATES_0=Path=/api/backend-service/**
     - SPRING_CLOUD_GATEWAY_ROUTES_1_FILTERS_0=RewritePath=/api/backend-service/(?<urlsegments>.*), /$\{urlsegments}
     - ALLOWED_ORIGINS_PUBLIC=http://localhost:*
     - ALLOWED_ORIGINS_CLIENTS=http://localhost:*


### PR DESCRIPTION
**Description**
- Fixed Env variable in Docker stack for route predicate missing `Path` prefix

**Reference**
Issues #203
