### PR TITLE
Feat/171 feature add findsecbugs

### DIFF
--- a/.github/workflows/dependency_review.yaml
+++ b/.github/workflows/dependency_review.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
         with:
           config-file: it-at-m/.github/workflow-configs/dependency_review.yaml@main
-          allow-dependencies-licenses: 'pkg:npm/escape-string-regexp, pkg:npm/path-exists, pkg:npm/slash, pkg:npm/yocto-queue, pkg:npm/load-script, pkg:npm/node-forge, pkg:maven/com.puppycrawl.tools/checkstyle, pkg:maven/com.hazelcast/hazelcast-spring, pkg:maven/com.github.spotbugs/spotbugs-annotations, pkg:maven/com.h3xstream.findsecbugs:findsecbugs-plugin'
+          allow-dependencies-licenses: 'pkg:npm/escape-string-regexp, pkg:npm/path-exists, pkg:npm/slash, pkg:npm/yocto-queue, pkg:npm/load-script, pkg:npm/node-forge, pkg:maven/com.puppycrawl.tools/checkstyle, pkg:maven/com.hazelcast/hazelcast-spring, pkg:maven/com.github.spotbugs/spotbugs-annotations, pkg:maven/com.h3xstream.findsecbugs/findsecbugs-plugin'

--- a/.github/workflows/dependency_review.yaml
+++ b/.github/workflows/dependency_review.yaml
@@ -13,4 +13,4 @@ jobs:
         uses: actions/dependency-review-action@5a2ce3f5b92ee19cbb1541a4984c76d921601d7c # v4.3.4
         with:
           config-file: it-at-m/.github/workflow-configs/dependency_review.yaml@main
-          allow-dependencies-licenses: 'pkg:npm/escape-string-regexp, pkg:npm/path-exists, pkg:npm/slash, pkg:npm/yocto-queue, pkg:npm/load-script, pkg:npm/node-forge, pkg:maven/com.puppycrawl.tools/checkstyle, pkg:maven/com.hazelcast/hazelcast-spring, pkg:maven/com.github.spotbugs/spotbugs-annotations'
+          allow-dependencies-licenses: 'pkg:npm/escape-string-regexp, pkg:npm/path-exists, pkg:npm/slash, pkg:npm/yocto-queue, pkg:npm/load-script, pkg:npm/node-forge, pkg:maven/com.puppycrawl.tools/checkstyle, pkg:maven/com.hazelcast/hazelcast-spring, pkg:maven/com.github.spotbugs/spotbugs-annotations, pkg:maven/com.h3xstream.findsecbugs:findsecbugs-plugin'

--- a/refarch-backend/pom.xml
+++ b/refarch-backend/pom.xml
@@ -37,6 +37,7 @@
         <pmd-maven-plugin.version>3.24.0</pmd-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.8.6</spotbugs-annotations.version>
+        <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
 
         <!-- Testing -->
         <jacoco-maven-plugin.version>0.8.12</jacoco-maven-plugin.version>
@@ -425,6 +426,13 @@
                 <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
                     <effort>Max</effort>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>${findsecbugs-plugin.version}</version>
+                        </plugin>
+                    </plugins>
                 </configuration>
                 <executions>
                     <execution>

--- a/refarch-backend/src/main/java/de/muenchen/refarch/configuration/nfcconverter/NfcRequest.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/configuration/nfcconverter/NfcRequest.java
@@ -11,7 +11,6 @@ import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -64,7 +63,7 @@ public class NfcRequest extends HttpServletRequestWrapper implements HttpServlet
     public String getHeader(final String name) {
         convert();
         final List<String> values = headers.get(NfcHelper.nfcConverter(name));
-        return (values == null) ? null : values.get(0);
+        return (values == null) ? null : values.getFirst();
     }
 
     @Override
@@ -192,7 +191,7 @@ public class NfcRequest extends HttpServletRequestWrapper implements HttpServlet
 
         final String encoding = getOriginalRequest().getCharacterEncoding();
 
-        String content;
+        final String content;
         try (InputStream is = getOriginalRequest().getInputStream()) {
             content = new String(IOUtils.toByteArray(is), encoding);
         }

--- a/refarch-backend/src/test/java/de/muenchen/refarch/configuration/CacheControlConfigurationTest.java
+++ b/refarch-backend/src/test/java/de/muenchen/refarch/configuration/CacheControlConfigurationTest.java
@@ -32,7 +32,8 @@ class CacheControlConfigurationTest {
 
     @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>(DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
+    @SuppressWarnings("unused")
+    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
 
     private static final String ENTITY_ENDPOINT_URL = "/theEntities";
 

--- a/refarch-backend/src/test/java/de/muenchen/refarch/configuration/UnicodeConfigurationTest.java
+++ b/refarch-backend/src/test/java/de/muenchen/refarch/configuration/UnicodeConfigurationTest.java
@@ -34,7 +34,8 @@ class UnicodeConfigurationTest {
 
     @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>(DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
+    @SuppressWarnings("unused")
+    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
 
     private static final String ENTITY_ENDPOINT_URL = "/theEntities";
 

--- a/refarch-backend/src/test/java/de/muenchen/refarch/rest/TheEntityRepositoryTest.java
+++ b/refarch-backend/src/test/java/de/muenchen/refarch/rest/TheEntityRepositoryTest.java
@@ -31,7 +31,8 @@ class TheEntityRepositoryTest {
 
     @Container
     @ServiceConnection
-    static PostgreSQLContainer<?> postgreSQLContainer = new PostgreSQLContainer<>(DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
+    @SuppressWarnings("unused")
+    private static final PostgreSQLContainer<?> POSTGRE_SQL_CONTAINER = new PostgreSQLContainer<>(DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
 
     @Autowired
     private TheEntityRepository repository;

--- a/refarch-eai/pom.xml
+++ b/refarch-eai/pom.xml
@@ -33,6 +33,7 @@
         <pmd-maven-plugin.version>3.24.0</pmd-maven-plugin.version>
         <spotbugs-maven-plugin.version>4.8.6.2</spotbugs-maven-plugin.version>
         <spotbugs-annotations.version>4.8.6</spotbugs-annotations.version>
+        <findsecbugs-plugin.version>1.13.0</findsecbugs-plugin.version>
 
         <!-- Logging -->
         <logstash-logback-encoder.version>7.4</logstash-logback-encoder.version>
@@ -256,6 +257,13 @@
                 <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
                     <effort>Max</effort>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.h3xstream.findsecbugs</groupId>
+                            <artifactId>findsecbugs-plugin</artifactId>
+                            <version>${findsecbugs-plugin.version}</version>
+                        </plugin>
+                    </plugins>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
**Description**
- Fixed some PMD errors
- Added findsecbugs plugin

**Reference**
Issues #171

**Notice**:
The addition of findsec bugs logs warnings when executing.
```
[java] The following classes needed for analysis were missing:
     [java]   customize
     [java]   apply
     [java]   accept
     [java]   makeConcatWithConstants
```

This is documented as a bug in find-sec-bugs: See https://github.com/find-sec-bugs/find-sec-bugs/issues/332
This might lead to some true positives not being found by the plugin (as stated in the bug discussion).
However we should still benefit from adding it to our toolchain.
