### PR TITLE
Maint/182 maintenance refactor main entrypoint class

### DIFF
--- a/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
@@ -1,25 +1,15 @@
 package de.muenchen.refarch;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
  * Application class for starting the microservice.
  */
-@Configuration
-@ComponentScan(
-        basePackages = {
-                "org.springframework.data.jpa.convert.threeten",
-                "de.muenchen.refarch"
-        }
-)
 @EntityScan(
         basePackages = {
-                "org.springframework.data.jpa.convert.threeten",
                 "de.muenchen.refarch"
         }
 )
@@ -28,10 +18,12 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
                 "de.muenchen.refarch"
         }
 )
-@EnableAutoConfiguration
+@SpringBootApplication(scanBasePackages = "de.muenchen.refarch")
 @SuppressWarnings("PMD.UseUtilityClass")
 public class MicroServiceApplication {
     public static void main(final String[] args) {
         SpringApplication.run(MicroServiceApplication.class, args);
     }
+
+
 }

--- a/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
@@ -2,17 +2,11 @@ package de.muenchen.refarch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
  * Application class for starting the microservice.
  */
-@EnableJpaRepositories(
-        basePackages = {
-                "de.muenchen.refarch"
-        }
-)
-@SpringBootApplication(scanBasePackages = "de.muenchen.refarch")
+@SpringBootApplication
 @SuppressWarnings("PMD.UseUtilityClass")
 public class MicroServiceApplication {
     public static void main(final String[] args) {

--- a/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
@@ -2,17 +2,11 @@ package de.muenchen.refarch;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 /**
  * Application class for starting the microservice.
  */
-@EntityScan(
-        basePackages = {
-                "de.muenchen.refarch"
-        }
-)
 @EnableJpaRepositories(
         basePackages = {
                 "de.muenchen.refarch"

--- a/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/MicroServiceApplication.java
@@ -24,6 +24,4 @@ public class MicroServiceApplication {
     public static void main(final String[] args) {
         SpringApplication.run(MicroServiceApplication.class, args);
     }
-
-
 }


### PR DESCRIPTION
**Description**

- added SpringBootApplication and removed componentScan, EnableAutoConfigurationand configuration. https://docs.spring.io/spring-boot/docs/2.0.x/reference/html/using-boot-using-springbootapplication-annotation.html
- removed "org.springframework.data.jpa.convert.threeten", its only needed for jdk 8 applications with older jpa versions. Newer versions are able to handle dates out of the box. You can test it by adding a LocalDate to the Entity `TheEntity` and add this code the `MicroServiceApplication` class
<details>
  <summary>Test Code</summary>

  ### Code
  ```java
 @Autowired
    TheEntityRepository repository;

    @Bean
    ApplicationRunner demo(){
        return args -> {
            LocalDate date = LocalDate.ofYearDay(2020, 8);
            System.out.println(date);
            TheEntity theEntity = new TheEntity();
            theEntity.setDate(date);
            theEntity.setTextAttribute("test");
            repository.save(theEntity);
            Iterable<TheEntity> theEntity2 = repository.findAll();
            System.out.println(theEntity2);
        };
    }
  ```
</details>

**Reference**

Issues #182 
