### PR TITLE
Maint/255 maintenance renovatebot ignore some updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -42,9 +42,34 @@
   "packageRules": [
     {
       "description": "Ignore spring-boot-parent updates in EAI template because Camel version specifies compatible Spring version",
+      "matchDatasources": ["maven"],
       "matchPackageNames": ["org.springframework.boot:spring-boot-starter-parent"],
       "matchFileNames": ["refarch-eai/pom.xml"],
       "enabled": false
+    },
+    {
+      "description": "Limit Camel updates to current LTS version (needs to be updated manually when new LTS release is out)",
+      "matchDatasources": ["maven"],
+      "matchPackageNames": ["org.apache.camel.springboot:camel-spring-boot-dependencies"],
+      "allowedVersions": "<=4.4"
+    },
+    {
+      "description": "Limit dependencies directly related to Node to versions on company machines (needs to be updated manually when new versions are rolled out)",
+      "matchDatasources": ["npm"],
+      "matchPackageNames": ["@types/node"],
+      "allowedVersions": "<=20.14.0"
+    },
+    {
+      "description": "Limit Keycloak version in docker stack to versions in company infrastructure, might slighty differ due to some RedHat KeyCloak versions not available as Docker image (needs to be updated manually when new versions are rolled out)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["quay.io/keycloak/keycloak"],
+      "allowedVersions": "<=20.0.5"
+    },
+    {
+      "description": "Limit Postgres version in docker stack to versions in company infrastructure (needs to be updated manually when new versions are rolled out)",
+      "matchDatasources": ["docker"],
+      "matchPackageNames": ["postgres"],
+      "allowedVersions": "<=16.4-alpine3.20"
     }
   ],
   "additionalBranchPrefix": "{{parentDir}}-"

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -3,7 +3,7 @@ name: default-services
 services:
   postgres:
     container_name: postgres
-    image: postgres:16.3-alpine3.18@sha256:64e18e8fb3e9c9aac89ac590c5dd8306b862478404f76cd9b5f7720d012b4c47
+    image: postgres:16.3-alpine3.20
     environment:
       - POSTGRES_DB=postgres
       - POSTGRES_USER=admin
@@ -64,7 +64,7 @@ services:
 
   db-postgres-keycloak:
     container_name: db-postgres-keycloak
-    image: postgres:16.3-alpine3.18@sha256:64e18e8fb3e9c9aac89ac590c5dd8306b862478404f76cd9b5f7720d012b4c47
+    image: postgres:16.3-alpine3.20
     environment:
       - POSTGRES_DB=keycloak
       - POSTGRES_USER=keycloak-user


### PR DESCRIPTION
**Description**
- Limited Camel updates to current LTS releases
- Limited directly node related deps to latest version on company machines
- Limited Keycloak version to the latest version in company infra
- Limited Postgres version to the latest version  in company infra

**Important:**: Those limits need to be manually updated once new version are rolled out.

**Reference**
Issues #255