### PR TITLE
Maint/158 maintenance make composition api default and remove compilation for options api features

### DIFF
--- a/refarch-frontend/src/components/common/Ad2ImageAvatar.vue
+++ b/refarch-frontend/src/components/common/Ad2ImageAvatar.vue
@@ -11,18 +11,18 @@ import { computed } from "vue";
 
 import { DefaultLhmAvatarService } from "@/api/Ad2ImageAvatarService";
 
-const { username, avatarMode = "fallbackGeneric", avatarSize = "64" } = defineProps<{
+const {
+  username,
+  avatarMode = "fallbackGeneric",
+  avatarSize = "64",
+} = defineProps<{
   username: string;
   avatarMode?: string;
   avatarSize?: string;
 }>();
 
 const avatarUrl = computed(() => {
-  return DefaultLhmAvatarService.avatarHref(
-    username,
-    avatarMode,
-    avatarSize
-  );
+  return DefaultLhmAvatarService.avatarHref(username, avatarMode, avatarSize);
 });
 
 const altText = computed(() => `Bild von ${username}`);

--- a/refarch-frontend/src/components/common/DatetimeInput.vue
+++ b/refarch-frontend/src/components/common/DatetimeInput.vue
@@ -86,7 +86,18 @@ import { computed, onMounted, ref, watch } from "vue";
 
 const modelValue = defineModel<string | null>();
 
-const { readonly = false, hideDetails = false, dense = false, filled = false, outlined = false, clearable = true, persistentHint = false, hint = "", label = "", rules = []} = defineProps<{
+const {
+  readonly = false,
+  hideDetails = false,
+  dense = false,
+  filled = false,
+  outlined = false,
+  clearable = true,
+  persistentHint = false,
+  hint = "",
+  label = "",
+  rules = [],
+} = defineProps<{
   readonly: boolean;
   hideDetails: boolean;
   dense: boolean;

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -12,8 +12,8 @@ export default defineConfig({
     vue({
       template: { transformAssetUrls },
       features: {
-        optionsAPI: false
-      }
+        optionsAPI: false,
+      },
     }),
     vuetify(),
     ViteFonts({

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -11,6 +11,9 @@ export default defineConfig({
   plugins: [
     vue({
       template: { transformAssetUrls },
+      features: {
+        optionsAPI: false
+      }
     }),
     vuetify(),
     ViteFonts({

--- a/refarch-webcomponent/vite.config.ts
+++ b/refarch-webcomponent/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     vue({
       features: {
         customElement: true,
-        optionsAPI: false
+        optionsAPI: false,
       },
     }),
   ],

--- a/refarch-webcomponent/vite.config.ts
+++ b/refarch-webcomponent/vite.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     vue({
       features: {
         customElement: true,
+        optionsAPI: false
       },
     }),
   ],
@@ -28,11 +29,8 @@ export default defineConfig({
     extensions: [".js", ".json", ".jsx", ".mjs", ".ts", ".tsx", ".vue"],
   },
   build: {
-    ssrManifest: true,
-    manifest: true,
+    manifest: true, // required for post build logic in 'processes' folder
     minify: true,
-    outDir: "dist",
-    emptyOutDir: false,
     rollupOptions: {
       input: {
         "refarch-hello-world-webcomponent":


### PR DESCRIPTION
**Description**
- Disabled Options API by default (smaller bundle size) -> Enforce Composition API usage
- Simplified Vite configuration for web component setup
- Prettier formatting

**Reference**
Issues #158
