### PR TITLE
Disable LogbackJsonLoggingConfigurationTest

### DIFF
--- a/refarch-backend/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingConfigurationTest.java
+++ b/refarch-backend/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingConfigurationTest.java
@@ -14,6 +14,7 @@ import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.MDC;
@@ -22,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles(SPRING_JSON_LOGGING_PROFILE)
 @ExtendWith(OutputCaptureExtension.class)
 @Slf4j
-@DirtiesContext // force logback config reset after test
+@Disabled("run manually on logback config changes")
 class LogbackJsonLoggingConfigurationTest {
 
     private static final String EXCEPTION_MESSAGE = "EXC_MESSAGE";

--- a/refarch-eai/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingConfigurationTest.java
+++ b/refarch-eai/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingConfigurationTest.java
@@ -14,6 +14,7 @@ import org.assertj.core.data.Percentage;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.MDC;
@@ -22,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 @ActiveProfiles(SPRING_JSON_LOGGING_PROFILE)
 @ExtendWith(OutputCaptureExtension.class)
 @Slf4j
-@DirtiesContext // force logback config reset after test
+@Disabled("run manually on logback config changes")
 class LogbackJsonLoggingConfigurationTest {
 
     private static final String EXCEPTION_MESSAGE = "EXC_MESSAGE";


### PR DESCRIPTION
**Description**

Disables LogbackJsonLoggingConfigurationTest as it cannot be integrated into test suite without sideffects.

If changes are made to Logback or it's configuration (which won't happen very often), the test can still be run manually by developers.

**Reference**

close #362 
