### PR TITLE
:bug: add missing spring-boot-maven-plugin for build

### DIFF
--- a/refarch-backend/pom.xml
+++ b/refarch-backend/pom.xml
@@ -295,6 +295,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>

--- a/refarch-eai/pom.xml
+++ b/refarch-eai/pom.xml
@@ -139,6 +139,10 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>


### PR DESCRIPTION
**Description**

Add missing `spring-boot-maven-plugin` to fix build. Without following exception occurs when starting the jar:

```
no main manifest attribute, in /deployments/matching-service-0.0.1-SNAPSHOT.jar
```
