### PR TITLE
:bug: renovate fix prs not created

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,7 +15,6 @@
     ":enableVulnerabilityAlertsWithLabel(Type: Security)", // custom label for security PRs created by Renovatebot
     ":npm", // updating package.json and package-lock.json
     ":pinAllExceptPeerDependencies", // do version pinning except for peer dependencies
-    ":prNotPending", // wait until branch succeeds or fails before creating the PR
     ":rebaseStalePrs", // rebase Renovate PR branched when base branch is updated
     ":semanticCommits", // enabled semantic commits in PR titles
     ":separateMultipleMajorReleases", // separate major updates of dependencies into separate PRs


### PR DESCRIPTION
**Description**

Fix renovate never creating PRs because of waiting for never running ci.

**Reference**

https://github.com/it-at-m/refarch/pull/221
