### PR TITLE
Maint/511 maintenance node 22 bump

### DIFF
--- a/refarch-frontend/package-lock.json
+++ b/refarch-frontend/package-lock.json
@@ -19,8 +19,8 @@
       "devDependencies": {
         "@mdi/js": "7.4.47",
         "@muenchen/prettier-codeformat": "1.0.2",
-        "@tsconfig/node20": "20.1.4",
-        "@types/node": "20.14.0",
+        "@tsconfig/node22": "22.0.0",
+        "@types/node": "22.9.0",
         "@vitejs/plugin-vue": "5.1.4",
         "@vue/eslint-config-prettier": "10.1.0",
         "@vue/eslint-config-typescript": "14.1.3",
@@ -38,7 +38,7 @@
         "vue-tsc": "2.1.10"
       },
       "engines": {
-        "node": ">=18 <=20"
+        "node": ">=20 <=22"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1150,9 +1150,9 @@
         "win32"
       ]
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.4",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.0",
+      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1169,12 +1169,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.14.0",
-      "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "version": "22.9.0",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/web-bluetooth": {
@@ -4060,8 +4060,8 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "6.19.8",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
       "dev": true,
       "license": "MIT"
     },

--- a/refarch-frontend/package-lock.json
+++ b/refarch-frontend/package-lock.json
@@ -19,7 +19,7 @@
       "devDependencies": {
         "@mdi/js": "7.4.47",
         "@muenchen/prettier-codeformat": "1.0.2",
-        "@tsconfig/node22": "22.0.0",
+        "@tsconfig/node-lts": "22.0.0",
         "@types/node": "22.9.0",
         "@vitejs/plugin-vue": "5.1.4",
         "@vue/eslint-config-prettier": "10.1.0",
@@ -1150,9 +1150,9 @@
         "win32"
       ]
     },
-    "node_modules/@tsconfig/node22": {
+    "node_modules/@tsconfig/node-lts": {
       "version": "22.0.0",
-      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
+      "integrity": "sha512-6y6CBFe0etz2xU1s0rGOj7pLsvbYXM9l/RNmBQOKI3S5DFrp1jigxx8uYupG5O6cCNXNlOE/1gquoQH01+kz5w==",
       "dev": true,
       "license": "MIT"
     },

--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "@mdi/js": "7.4.47",
     "@muenchen/prettier-codeformat": "1.0.2",
-    "@tsconfig/node22": "22.0.0",
+    "@tsconfig/node-lts": "22.0.0",
     "@types/node": "22.9.0",
     "@vitejs/plugin-vue": "5.1.4",
     "@vue/eslint-config-prettier": "10.1.0",

--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=18 <=20"
+    "node": ">=20 <=22"
   },
   "scripts": {
     "dev": "vite",
@@ -26,8 +26,8 @@
   "devDependencies": {
     "@mdi/js": "7.4.47",
     "@muenchen/prettier-codeformat": "1.0.2",
-    "@tsconfig/node20": "20.1.4",
-    "@types/node": "20.14.0",
+    "@tsconfig/node22": "22.0.0",
+    "@types/node": "22.9.0",
     "@vitejs/plugin-vue": "5.1.4",
     "@vue/eslint-config-prettier": "10.1.0",
     "@vue/eslint-config-typescript": "14.1.3",

--- a/refarch-frontend/tsconfig.node.json
+++ b/refarch-frontend/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "include": ["vite.config.*", "vitest.config.*"],
   "compilerOptions": {
     "composite": true,

--- a/refarch-frontend/tsconfig.node.json
+++ b/refarch-frontend/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
   "include": ["vite.config.*", "vitest.config.*"],
   "compilerOptions": {
     "composite": true,

--- a/refarch-webcomponent/package-lock.json
+++ b/refarch-webcomponent/package-lock.json
@@ -14,8 +14,8 @@
       },
       "devDependencies": {
         "@muenchen/prettier-codeformat": "1.0.2",
-        "@tsconfig/node20": "20.1.4",
-        "@types/node": "20.14.0",
+        "@tsconfig/node22": "22.0.0",
+        "@types/node": "22.9.0",
         "@vitejs/plugin-vue": "5.1.4",
         "@vue/eslint-config-prettier": "10.1.0",
         "@vue/eslint-config-typescript": "14.1.3",
@@ -31,7 +31,7 @@
         "vue-tsc": "2.1.10"
       },
       "engines": {
-        "node": ">=18 <=20"
+        "node": ">=20 <=22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1165,10 +1165,11 @@
         "win32"
       ]
     },
-    "node_modules/@tsconfig/node20": {
-      "version": "20.1.4",
-      "integrity": "sha512-sqgsT69YFeLWf5NtJ4Xq/xAF8p4ZQHlmGW74Nu2tD4+g5fAsposc4ZfaaPixVu4y01BEiDCWLRDCvDM5JOsRxg==",
-      "dev": true
+    "node_modules/@tsconfig/node22": {
+      "version": "22.0.0",
+      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.6",
@@ -1181,11 +1182,12 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.14.0",
-      "integrity": "sha512-5cHBxFGJx6L4s56Bubp4fglrEpmyJypsqI6RgzMfBHWUJQGWAAi8cWcgetEbZXHYXo9C2Fa4EEds/uSyS4cxmA==",
+      "version": "22.9.0",
+      "integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.19.8"
       }
     },
     "node_modules/@types/web-bluetooth": {
@@ -3895,9 +3897,10 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.19.8",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.1.1",

--- a/refarch-webcomponent/package-lock.json
+++ b/refarch-webcomponent/package-lock.json
@@ -14,7 +14,7 @@
       },
       "devDependencies": {
         "@muenchen/prettier-codeformat": "1.0.2",
-        "@tsconfig/node22": "22.0.0",
+        "@tsconfig/node-lts": "22.0.0",
         "@types/node": "22.9.0",
         "@vitejs/plugin-vue": "5.1.4",
         "@vue/eslint-config-prettier": "10.1.0",
@@ -1165,9 +1165,9 @@
         "win32"
       ]
     },
-    "node_modules/@tsconfig/node22": {
+    "node_modules/@tsconfig/node-lts": {
       "version": "22.0.0",
-      "integrity": "sha512-twLQ77zevtxobBOD4ToAtVmuYrpeYUh3qh+TEp+08IWhpsrIflVHqQ1F1CiPxQGL7doCdBIOOCF+1Tm833faNg==",
+      "integrity": "sha512-6y6CBFe0etz2xU1s0rGOj7pLsvbYXM9l/RNmBQOKI3S5DFrp1jigxx8uYupG5O6cCNXNlOE/1gquoQH01+kz5w==",
       "dev": true,
       "license": "MIT"
     },

--- a/refarch-webcomponent/package.json
+++ b/refarch-webcomponent/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=18 <=20"
+    "node": ">=20 <=22"
   },
   "scripts": {
     "dev": "vite",
@@ -22,8 +22,8 @@
   },
   "devDependencies": {
     "@muenchen/prettier-codeformat": "1.0.2",
-    "@tsconfig/node20": "20.1.4",
-    "@types/node": "20.14.0",
+    "@tsconfig/node22": "22.0.0",
+    "@types/node": "22.9.0",
     "@vitejs/plugin-vue": "5.1.4",
     "@vue/eslint-config-prettier": "10.1.0",
     "@vue/eslint-config-typescript": "14.1.3",

--- a/refarch-webcomponent/package.json
+++ b/refarch-webcomponent/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@muenchen/prettier-codeformat": "1.0.2",
-    "@tsconfig/node22": "22.0.0",
+    "@tsconfig/node-lts": "22.0.0",
     "@types/node": "22.9.0",
     "@vitejs/plugin-vue": "5.1.4",
     "@vue/eslint-config-prettier": "10.1.0",

--- a/refarch-webcomponent/processes/post-build.js
+++ b/refarch-webcomponent/processes/post-build.js
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { generateLoaderJs } from './lib/fileGenerator.js';
-import manifest from '../dist/src/.vite/manifest.json' assert {type: 'json'};
+import manifest from '../dist/src/.vite/manifest.json' with {type: 'json'};
 
 /**
  * Why this?

--- a/refarch-webcomponent/tsconfig.node.json
+++ b/refarch-webcomponent/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node20/tsconfig.json",
+  "extends": "@tsconfig/node22/tsconfig.json",
   "include": ["vite.config.*", "vitest.config.*"],
   "compilerOptions": {
     "composite": true,

--- a/refarch-webcomponent/tsconfig.node.json
+++ b/refarch-webcomponent/tsconfig.node.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node22/tsconfig.json",
+  "extends": "@tsconfig/node-lts/tsconfig.json",
   "include": ["vite.config.*", "vitest.config.*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
**Description**
- Replaces explicit @tsconfig/node20 with @tsconfig/node-lts to more easily bump versions instead of switching dep
- Fixed build script in webcomponent
- Updated TypeScript configuration files
- Updated Node requirements of templates to Node 20 and Node 22

**Reference**
Issues #511
