### PR TITLE
Fix Appswitcher icon missing

### DIFF
--- a/refarch-frontend/src/App.vue
+++ b/refarch-frontend/src/App.vue
@@ -41,6 +41,7 @@
             v-if="appswitcherBaseUrl"
             :base-url="appswitcherBaseUrl"
             :tags="['global']"
+            icon="$appswitcher"
           />
           <v-btn
             variant="text"

--- a/refarch-frontend/src/App.vue
+++ b/refarch-frontend/src/App.vue
@@ -41,7 +41,7 @@
             v-if="appswitcherBaseUrl"
             :base-url="appswitcherBaseUrl"
             :tags="['global']"
-            icon="$appswitcher"
+            :icon="mdiApps"
           />
           <v-btn
             variant="text"
@@ -75,7 +75,7 @@
 </template>
 
 <script setup lang="ts">
-import { mdiMagnify } from "@mdi/js";
+import { mdiApps, mdiMagnify } from "@mdi/js";
 import { AppSwitcher } from "@muenchen/appswitcher-vue";
 import { useToggle } from "@vueuse/core";
 import { onMounted, ref } from "vue";

--- a/refarch-frontend/src/plugins/vuetify.ts
+++ b/refarch-frontend/src/plugins/vuetify.ts
@@ -1,12 +1,16 @@
 import "vuetify/styles";
 
+import { mdiApps } from "@mdi/js";
 import { createVuetify } from "vuetify";
 import { aliases, mdi } from "vuetify/iconsets/mdi-svg";
 
 export default createVuetify({
   icons: {
     defaultSet: "mdi",
-    aliases,
+    aliases: {
+      ...aliases,
+      appswitcher: mdiApps,
+    },
     sets: {
       mdi,
     },

--- a/refarch-frontend/src/plugins/vuetify.ts
+++ b/refarch-frontend/src/plugins/vuetify.ts
@@ -1,16 +1,12 @@
 import "vuetify/styles";
 
-import { mdiApps } from "@mdi/js";
 import { createVuetify } from "vuetify";
 import { aliases, mdi } from "vuetify/iconsets/mdi-svg";
 
 export default createVuetify({
   icons: {
     defaultSet: "mdi",
-    aliases: {
-      ...aliases,
-      appswitcher: mdiApps,
-    },
+    aliases,
     sets: {
       mdi,
     },


### PR DESCRIPTION
explicitely import used icon and provide alias for appswitcher icon

**Description**

AFAIK without using something like https://github.com/antfu/unplugin-icons custom Icons must be imported explicitely, see https://vuetifyjs.com/en/features/icon-fonts/#mdi-js-svg

Currently only icons used internally by vuetify are avaible ("mdi-apps" is missing from this set).

**Reference**

https://github.com/it-at-m/appswitcher-vue/issues/417
