### PR TITLE
:recycle: Providing fonts locally

### DIFF
--- a/refarch-frontend/package-lock.json
+++ b/refarch-frontend/package-lock.json
@@ -12,7 +12,6 @@
         "@muenchen/appswitcher-vue": "2.1.0",
         "@vueuse/core": "12.0.0",
         "pinia": "2.2.8",
-        "roboto-fontface": "0.10.0",
         "vue": "3.5.13",
         "vue-router": "4.5.0",
         "vuetify": "3.7.5"
@@ -4638,11 +4637,6 @@
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/roboto-fontface": {
-      "version": "0.10.0",
-      "integrity": "sha512-OlwfYEgA2RdboZohpldlvJ1xngOins5d7ejqnIBWr9KaMxsnBqotpptRXTyfNRLnFpqzX6sTDt+X+a+6udnU8g==",
-      "license": "Apache-2.0"
     },
     "node_modules/rollup": {
       "version": "4.27.3",

--- a/refarch-frontend/package-lock.json
+++ b/refarch-frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "refarch-frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@fontsource/roboto": "5.1.0",
         "@muenchen/appswitcher-vue": "2.1.0",
         "@vueuse/core": "12.0.0",
         "pinia": "2.2.8",
@@ -1042,6 +1043,11 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@fontsource/roboto": {
+      "version": "5.1.0",
+      "integrity": "sha512-cFRRC1s6RqPygeZ8Uw/acwVHqih8Czjt6Q0MwoUoDe9U3m4dH1HmNDRBZyqlMSFwgNAUKgFImncKdmDHyKpwdg==",
+      "license": "Apache-2.0"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",

--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -15,6 +15,7 @@
     "fix": "prettier . --write && eslint . --fix"
   },
   "dependencies": {
+    "@fontsource/roboto": "5.1.0",
     "@muenchen/appswitcher-vue": "2.1.0",
     "@vueuse/core": "12.0.0",
     "pinia": "2.2.8",

--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -19,7 +19,6 @@
     "@muenchen/appswitcher-vue": "2.1.0",
     "@vueuse/core": "12.0.0",
     "pinia": "2.2.8",
-    "roboto-fontface": "0.10.0",
     "vue": "3.5.13",
     "vue-router": "4.5.0",
     "vuetify": "3.7.5"

--- a/refarch-frontend/src/main.ts
+++ b/refarch-frontend/src/main.ts
@@ -3,6 +3,8 @@ import { createApp } from "vue";
 import App from "@/App.vue";
 import { registerPlugins } from "@/plugins";
 
+import "unfonts.css";
+
 const app = createApp(App);
 
 registerPlugins(app);

--- a/refarch-frontend/tsconfig.app.json
+++ b/refarch-frontend/tsconfig.app.json
@@ -9,6 +9,7 @@
       "@/*": ["./src/*"]
     },
     "allowSyntheticDefaultImports": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "types": ["unplugin-fonts/client"]
   }
 }

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -20,11 +20,12 @@ export default defineConfig({
       autoImport: false,
     }),
     UnpluginFonts({
-      google: {
+      fontsource: {
         families: [
           {
             name: "Roboto",
-            styles: "wght@100;300;400;500;700;900",
+            weights: [100, 300, 400, 500, 700, 900],
+            subset: "latin",
           },
         ],
       },


### PR DESCRIPTION
**Description**
- Added fontsource dependency to download Roboto font as npm package
- Changed unplugin fonts configuration to make use of fontsource npm package
- Only included `latin` fontset and the specific versions required by Vuetify
- Fonts are no longer fetched from Google servers

**Reference**
Issues #85


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced the Roboto font for enhanced styling options.
	- Added support for custom font management through updated configurations.

- **Bug Fixes**
	- No bug fixes were included in this release.

- **Documentation**
	- Updated dependencies and configurations documented for clarity.

- **Chores**
	- Updated project files to include new font dependencies and configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->