### PR TITLE
Maint/621 maintenance clean up applicationyml by removing properties which are set to default values

### DIFF
--- a/refarch-backend/src/main/java/de/muenchen/refarch/theentity/TheEntity.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/theentity/TheEntity.java
@@ -32,7 +32,7 @@ public class TheEntity extends BaseEntity {
     // Variables //
     // ========= //
 
-    @Column(name = "textattribute", nullable = false, length = 8)
+    @Column(nullable = false, length = 8)
     @NotNull
     @Size(min = 2, max = 8)
     private String textAttribute;

--- a/refarch-backend/src/main/resources/application-local.yml
+++ b/refarch-backend/src/main/resources/application-local.yml
@@ -9,7 +9,6 @@ spring:
       # is also the default, that spring offers by convention.
       # but here explicite:
       ddl-auto: create-drop
-      naming.physical-strategy: org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
     # Logging for database operation
     show-sql: true
     properties:

--- a/refarch-backend/src/main/resources/application.yml
+++ b/refarch-backend/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
-  application.name: @project.artifactId@
-  banner.location: banner.txt
+  application:
+    name: @project.artifactId@
   security:
     oauth2:
       resourceserver:
@@ -10,26 +10,14 @@ spring:
           # requires client to be in audience claim, see https://www.keycloak.org/docs/latest/server_admin/#_audience_resolve
           # TODO - should be the clientId of the actual project
           - refarch
-  # Spring data rest
-  data:
-    rest:
-      # Definition of page size for PagingAndSortingRepository
-      max-page-size: 0x7fffffff
-      default-page-size: 0x7fffffff
-      return-body-on-update: true
-      return-body-on-create: true
 
 server:
-  port: 8080
   error:
-    include-exception: false
-    include-stacktrace: never
     whitelabel:
       enabled: false
 
 # Config for spring actuator endpoints
 management:
-  server.port: ${server.port}
   endpoints:
     access:
       default: none

--- a/refarch-eai/src/main/resources/application-local.yml
+++ b/refarch-eai/src/main/resources/application-local.yml
@@ -1,2 +1,2 @@
 server:
-  port: 8084
+  port: 8085

--- a/refarch-eai/src/main/resources/application.yml
+++ b/refarch-eai/src/main/resources/application.yml
@@ -1,33 +1,28 @@
-camel:
-  springboot:
-    main-run-controller: true
-    tracing: false
-  servlet:
-    mapping:
-      context-path: /api/*
-
 spring:
   application:
     name: @project.artifactId@
 
 server:
   shutdown: "graceful"
+  error:
+    whitelabel:
+      enabled: false
 
 management:
   endpoints:
     enabled-by-default: false
     web:
       exposure:
-        include: health,info, prometheus
+        include: health, info, prometheus
       path-mapping:
         prometheus: metrics
   endpoint:
-    info:
-      enabled: true
     health:
       enabled: true
       probes:
         enabled: true
+    info:
+      enabled: true
     prometheus:
       enabled: true
   info:
@@ -50,10 +45,10 @@ info:
     java.version: @java.version@
     camel.version: @camel-spring-boot-dependencies.version@
 
-logging:
-  level:
-    org:
-      springframework: INFO
+camel:
+  servlet:
+    mapping:
+      context-path: /api/*
 
 # Custom properties
 output: direct:foo


### PR DESCRIPTION
**Description**
- Simplified and aligned the application.yml files
- Removed Hibernate naming strategy for local profile
- Removed `column` annotation in entities to inter via Hibernate

**Reference**
Issues #621


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Configuration Changes**
  - Simplified database column mapping for `textAttribute` by removing explicit column name.
  - Removed `naming.physical-strategy` from Hibernate settings, streamlining configuration.
  - Restructured application configuration for better organization, removing unnecessary properties related to data rest and error handling.
  - Updated server port from 8084 to 8085 in local configurations.
  - Added new error handling settings to disable the default error page.

These updates enhance the application's configuration clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->