### PR TITLE
:recycle: backend cleanup local sso conf

### DIFF
--- a/refarch-backend/src/main/resources/application-local.yml
+++ b/refarch-backend/src/main/resources/application-local.yml
@@ -26,7 +26,7 @@ spring:
           audiences:
             - ${sso.client}
 
-# Define the local keycloak realm here
+# Define the local keycloak configuration here
 sso:
   url: http://localhost:8100
   realm: local_realm

--- a/refarch-backend/src/main/resources/application-local.yml
+++ b/refarch-backend/src/main/resources/application-local.yml
@@ -27,6 +27,7 @@ spring:
             - ${sso.client}
 
 # Define the local keycloak configuration here
+# Deduplication-only property
 sso:
   url: http://localhost:8100
   realm: local_realm

--- a/refarch-backend/src/main/resources/application-local.yml
+++ b/refarch-backend/src/main/resources/application-local.yml
@@ -22,16 +22,17 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: ${keycloak.auth-server-url}/auth/realms/${realm}/protocol/openid-connect/certs
+          jwk-set-uri: ${sso.url}/auth/realms/${sso.realm}/protocol/openid-connect/certs
           audiences:
-            - local
+            - ${sso.client}
 
 # Define the local keycloak realm here
-realm: local_realm
-keycloak:
-  auth-server-url: http://keycloak:8100
+sso:
+  url: http://localhost:8100
+  realm: local_realm
+  client: local
 
 security:
   # possible values: none, all, changing (With changing, only changing requests such as POST, PUT, DELETE are logged)
   requestLogging: all
-  userInfoUri: ${keycloak.auth-server-url}/auth/realms/${realm}/protocol/openid-connect/userinfo
+  userInfoUri: ${sso.url}/auth/realms/${sso.realm}/protocol/openid-connect/userinfo


### PR DESCRIPTION
**Description**

Cleanup backend local sso configuration.
Use keycloak hostname `localhost` instead of `keycloak` so that users do not have to customize the hosts file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new Single Sign-On (SSO) configuration for enhanced security and modularity.
- **Bug Fixes**
	- Updated security properties to improve integration with identity providers.
- **Chores**
	- Removed outdated Keycloak configuration to streamline settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->