### PR TITLE
Maint/434 feature add frontend and webcomponent preview servers to gateway route configuration

### DIFF
--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -10,7 +10,6 @@
     "dev": "vite",
     "test": "vitest run",
     "build": "vue-tsc --build --noCheck && vite build",
-    "preview": "vite preview",
     "lint": "prettier . --check && eslint . && vue-tsc --noEmit",
     "fix": "prettier . --write && eslint . --fix"
   },

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     vueDevTools(),
   ],
   server: {
+    host: true,
     port: 8081,
     proxy: {
       "/api": "http://localhost:8083",

--- a/stack/docker-compose.yml
+++ b/stack/docker-compose.yml
@@ -113,6 +113,9 @@ services:
     - SPRING_CLOUD_GATEWAY_ROUTES_1_URI=http://host.docker.internal:39146/
     - SPRING_CLOUD_GATEWAY_ROUTES_1_PREDICATES_0=Path=/api/backend-service/**
     - SPRING_CLOUD_GATEWAY_ROUTES_1_FILTERS_0=RewritePath=/api/backend-service/(?<urlsegments>.*), /$\{urlsegments}
+    - SPRING_CLOUD_GATEWAY_ROUTES_2_ID=frontend
+    - SPRING_CLOUD_GATEWAY_ROUTES_2_URI=http://host.docker.internal:8081/
+    - SPRING_CLOUD_GATEWAY_ROUTES_2_PREDICATES_0=Path=/**
     - SPRING_PROFILES_ACTIVE=hazelcast-local
     - SPRING_SECURITY_OAUTH2_RESOURCESERVER_JWT_ISSUERURI=http://kubernetes.docker.internal:8100/auth/realms/local_realm
     - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_SSO_ISSUERURI=$${spring.security.oauth2.resourceserver.jwt.issuer-uri}


### PR DESCRIPTION
**Description**
- Updated configurations to use local frontend Vite dev server behind API gateway

I explictly did not include it for webcomponents as it does not make sense for local development to use the webcomponent dev server behind the gateway. (only loader files are interesting for webcomponents which are only created on build)

**Reference**
Issues #434


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new route configuration in the `refarch-gateway` service for improved traffic handling.
	- Enhanced accessibility of the Vite server for development across different devices.

- **Bug Fixes**
	- Standardized healthcheck configurations across multiple services for better monitoring and reliability.

- **Chores**
	- Removed the preview script from the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->