### PR TITLE
Revert "chore(deps): update softprops/action-gh-release action to v2.2.0"

### DIFF
--- a/.github/workflows/release-maven-image.yaml
+++ b/.github/workflows/release-maven-image.yaml
@@ -63,7 +63,7 @@ jobs:
           name: ${{ needs.release-maven.outputs.ARTIFACT_NAME }}
       - name: Create GitHub Release
         id: create_release
-        uses: softprops/action-gh-release@7b4da11513bf3f43f9999e90eabced41ab8bb048 # v2.2.0
+        uses: softprops/action-gh-release@01570a1f39cb168c169c802c3bceb9e93fb10974 # v2.1.0
         with:
           tag_name: ${{needs.release-maven.outputs.MVN_ARTIFACT_ID}}-${{ github.event.inputs.releaseVersion }}
           draft: false


### PR DESCRIPTION
Reverts it-at-m/refarch-templates#650

Siehe https://github.com/it-at-m/refarch-templates/pull/650#issuecomment-2548217782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the version of the action used for creating GitHub releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->