### PR TITLE
Maint/682 maintenance pin supported node versions to lts version

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -139,7 +139,7 @@ By default, the template supports two Maven profiles:
 
 ### Prerequisites
 
-- Node.js version 20 to 22
+- Node.js 22 LTS (`22.11.x` - `22.x.x`)
 - Docker (for AppSwitcher)
 
 ### Configure Templates

--- a/refarch-frontend/package-lock.json
+++ b/refarch-frontend/package-lock.json
@@ -39,7 +39,7 @@
         "vue-tsc": "2.2.0"
       },
       "engines": {
-        "node": ">=20 <=22"
+        "node": ">=22.11 <=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=20 <=22"
+    "node": ">=22.11 <=22"
   },
   "scripts": {
     "dev": "vite",

--- a/refarch-webcomponent/package-lock.json
+++ b/refarch-webcomponent/package-lock.json
@@ -32,7 +32,7 @@
         "vue-tsc": "2.2.0"
       },
       "engines": {
-        "node": ">=20 <=22"
+        "node": "=22"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/refarch-webcomponent/package.json
+++ b/refarch-webcomponent/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "private": true,
   "engines": {
-    "node": ">=20 <=22"
+    "node": ">=22.11 <=22"
   },
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
**Description**
- Update Node requirements to the current LTS windows of Node (22.11 and higher, lower than 23)

**Reference**
Issues #682


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated Getting Started guide with precise Node.js version requirements
	- Clarified Node.js version compatibility for Frontend and Web Components templates

- **Chores**
	- Updated `package.json` files to specify Node.js version range as 22.11.x to 22.x.x
	- Refined Node.js engine version constraints across projects

<!-- end of auto-generated comment: release notes by coderabbit.ai -->