### PR TITLE
Bug/636 bug x frame options cannot be disabled using spring mechanism

### DIFF
--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -42,14 +42,14 @@ export default defineConfig(({ mode }) => {
         "/actuator": "http://localhost:8083",
       },
       headers: {
-        "x-frame-options": "SAMEORIGIN" // required to use devtools behind proxy (e.g. API gateway)
-      }
+        "x-frame-options": "SAMEORIGIN", // required to use devtools behind proxy (e.g. API gateway)
+      },
     },
     resolve: {
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
-    logLevel: "info"
+    logLevel: "info",
   };
 });

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -50,6 +50,5 @@ export default defineConfig(({ mode }) => {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
-    logLevel: "info",
   };
 });

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -41,11 +41,15 @@ export default defineConfig(({ mode }) => {
         "/api": "http://localhost:8083",
         "/actuator": "http://localhost:8083",
       },
+      headers: {
+        "x-frame-options": "SAMEORIGIN" // required to use devtools behind proxy (e.g. API gateway)
+      }
     },
     resolve: {
       alias: {
         "@": fileURLToPath(new URL("./src", import.meta.url)),
       },
     },
+    logLevel: "info"
   };
 });


### PR DESCRIPTION
**Description**
- Fix usage of devtools behind proxy (e.g. gateway) by setting X-Frame-Options in Vite devserver

**Reference**
Issues #636


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
	- Enhanced application security by adding X-Frame-Options header in development environment to prevent potential clickjacking attacks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->