### PR TITLE
Add linting of docs to GitHub workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,8 +25,6 @@ jobs:
     steps:
       - id: build_docs
         uses: it-at-m/.github/.github/actions/action-build-docs@main
-        with:
-          app-path: ${{inputs.app-path}}
       - id: deploy_docs
         # Only deploy documentation from the main branch to prevent unauthorized changes
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,7 +1,7 @@
 name: Deploy documentation website
 
 on:
-  # Runs on pushes targeting the `main` branch
+  # Runs on pushes on branches
   push:
     paths:
       - "docs/**"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths:
       - "docs/**"
-      - ".github/**"
+      - "".github/workflows/deploy-docs.yml""
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -3,11 +3,31 @@ name: Deploy documentation website
 on:
   # Runs on pushes targeting the `main` branch
   push:
-    branches: [main]
     paths:
       - "docs/**"
-      - ".github/workflows/deploy-docs.yml" # define the concrete paths on which a change triggers this action, e.g. backend/**
+      - ".github/workflows/deploy-docs.yml" # define the concrete paths on which a change triggers this action, e.g. docs/**
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  deploy-pages:
-    uses: it-at-m/.github/.github/workflows/deploy-pages.yml@main
+  deploy-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - id: build_docs
+        uses: it-at-m/.github/.github/actions/action-build-docs@main
+        with:
+          app-path: ${{inputs.app-path}}
+      - id: deploy_docs
+        if: (github.ref_name == 'main')
+
+        uses: it-at-m/.github/.github/actions/action-deploy-docs@main

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,11 +1,11 @@
 name: Deploy documentation website
 
 on:
-  # Runs on pushes on branches
+  # Runs on pushes to any branch when changes are made to docs or workflow
   push:
     paths:
       - "docs/**"
-      - "".github/workflows/deploy-docs.yml""
+      - ".github/workflows/deploy-docs.yml"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,6 +29,5 @@ jobs:
           app-path: ${{inputs.app-path}}
       - id: deploy_docs
         # Only deploy documentation from the main branch to prevent unauthorized changes
-        if: (github.ref_name == 'main')
 
         uses: it-at-m/.github/.github/actions/action-deploy-docs@main

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths:
       - "docs/**"
-      - ".github/workflows/deploy-docs.yml" # define the concrete paths on which a change triggers this action, e.g. docs/**
+      - ".github/workflows/deploy-docs.yml"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -5,7 +5,7 @@ on:
   push:
     paths:
       - "docs/**"
-      - ".github/workflows/deploy-docs.yml"
+      - ".github/**"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           app-path: ${{inputs.app-path}}
       - id: deploy_docs
+        # Only deploy documentation from the main branch to prevent unauthorized changes
         if: (github.ref_name == 'main')
 
         uses: it-at-m/.github/.github/actions/action-deploy-docs@main

--- a/.github/workflows/maven-node-build.yaml
+++ b/.github/workflows/maven-node-build.yaml
@@ -19,6 +19,7 @@ jobs:
           - app-path: refarch-frontend
           - app-path: refarch-eai
           - app-path: refarch-webcomponent
+          - app-path: docs
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - if:  ${{hashFiles(format('./{0}/package.json', matrix.app-path))!=null}}

--- a/.github/workflows/maven-node-build.yaml
+++ b/.github/workflows/maven-node-build.yaml
@@ -19,15 +19,15 @@ jobs:
           - app-path: refarch-frontend
           - app-path: refarch-eai
           - app-path: refarch-webcomponent
-          - app-path: docs
+
     steps:
       - uses: it-at-m/.github/.github/actions/action-checkout@main
-      - if:  ${{hashFiles(format('./{0}/package.json', matrix.app-path))!=null}}
+      - if: ${{hashFiles(format('./{0}/package.json', matrix.app-path))!=null}}
         id: node
         uses: it-at-m/.github/.github/actions/action-npm-build@main
         with:
-          app-path:  "${{ matrix.app-path }}"
-      - if:  ${{hashFiles(format('./{0}/pom.xml', matrix.app-path))!=null}}
+          app-path: "${{ matrix.app-path }}"
+      - if: ${{hashFiles(format('./{0}/pom.xml', matrix.app-path))!=null}}
         id: maven
         uses: it-at-m/.github/.github/actions/action-maven-build@main
         with:


### PR DESCRIPTION
**Description**
- Added `docs` npm project to build workflow

**Reference**
Issues #721


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to include the `docs` application path in the build process.
	- Enhanced deployment workflow for documentation by allowing pushes on any branch, establishing permissions, and restructuring job steps for improved clarity and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->