### PR TITLE
Bug/777 bug maven build produces incompatible named jar

### DIFF
--- a/refarch-backend/pom.xml
+++ b/refarch-backend/pom.xml
@@ -456,6 +456,7 @@
                 <configuration>
                     <effort>Max</effort>
                     <excludeFilterFile>spotbugs-exclude-rules.xml</excludeFilterFile>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs-results</spotbugsXmlOutputDirectory> <!-- required to ensure only the artifact jar is on top level when building -->
                     <plugins>
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>

--- a/refarch-eai/pom.xml
+++ b/refarch-eai/pom.xml
@@ -276,6 +276,8 @@
                 <version>${spotbugs-maven-plugin.version}</version>
                 <configuration>
                     <effort>Max</effort>
+                    <excludeFilterFile>spotbugs-exclude-rules.xml</excludeFilterFile>
+                    <spotbugsXmlOutputDirectory>${project.build.directory}/spotbugs-results</spotbugsXmlOutputDirectory> <!-- required to ensure only the artifact jar is on top level when building -->
                     <plugins>
                         <plugin>
                             <groupId>com.h3xstream.findsecbugs</groupId>

--- a/refarch-eai/spotbugs-exclude-rules.xml
+++ b/refarch-eai/spotbugs-exclude-rules.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="CRLF_INJECTION_LOGS"/>
+    </Match>
+</FindBugsFilter>


### PR DESCRIPTION
**Description**
- Changed spotbugs maven configuration to move results to subdirectory -> ensures only 1 jar on toplevel
- Aligned spotbugs plugin configuration between backend and EAI template

See https://github.com/spotbugs/spotbugs-maven-plugin/issues/296 for more information.

**Reference**
Issues #777


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced the build process by optimizing configuration for automated code quality checks, resulting in better-organized analysis reports.
  - Introduced updated filtering rules to reduce false alarms and focus on meaningful quality feedback.
  - These progressive improvements contribute to a more robust and streamlined development workflow, ensuring sustained product quality and optimal performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->