### PR TITLE
Fixed JavaScript Linter errors not being checked in TypeScript files when running "npm lint"

### DIFF
--- a/refarch-frontend/package.json
+++ b/refarch-frontend/package.json
@@ -10,7 +10,7 @@
     "dev": "vite",
     "test": "vitest run",
     "build": "vue-tsc --build --noCheck && vite build",
-    "lint": "prettier . --check && eslint . && vue-tsc --noEmit",
+    "lint": "prettier . --check && eslint . && vue-tsc --build --noEmit",
     "fix": "prettier . --write && eslint . --fix"
   },
   "dependencies": {

--- a/refarch-frontend/src/plugins/vuetify.ts
+++ b/refarch-frontend/src/plugins/vuetify.ts
@@ -1,3 +1,4 @@
+// @ts-expect-error: "TS2307 cannot find module" is a false positive here
 import "vuetify/styles";
 
 import { createVuetify } from "vuetify";

--- a/refarch-webcomponent/package.json
+++ b/refarch-webcomponent/package.json
@@ -12,7 +12,7 @@
     "build": "vue-tsc --build --noCheck && vite build && npm run post-build",
     "post-build": "node ./processes/post-build.js",
     "preview": "vite preview",
-    "lint": "prettier . --check && eslint . && vue-tsc --noEmit",
+    "lint": "prettier . --check && eslint . && vue-tsc --build --noEmit",
     "fix": "prettier . --write && eslint . --fix"
   },
   "dependencies": {


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch-templates.oss.muenchen.de/document.html#writing-the-documentation
[code-quality-link]: https://refarch-templates.oss.muenchen.de/develop.html#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose

## Changes
- Extended execution of `vue-tsc` to build when linting, because otherwise only type-checking is done
- Added ts ignore for vuetify style import due to bug in type system

## Reference
Issue: #719

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [ ] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English

## Screenshots (if UI was changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**  
  - Refined the linting scripts across projects to incorporate a more robust build validation check during the code verification process.  
  - Updated internal documentation notes to clarify expected behavior, ensuring seamless integration with UI components without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->