### PR TITLE
maint/545-maintenance-handling-spotbugs-internal-representation-ei_expose_rep into main

### DIFF
--- a/refarch-backend/lombok.config
+++ b/refarch-backend/lombok.config
@@ -1,3 +1,0 @@
-config.stopBubbling = true
-lombok.addLombokGeneratedAnnotation = true
-lombok.extern.findbugs.addSuppressFBWarnings = true

--- a/refarch-backend/spotbugs-exclude-rules.xml
+++ b/refarch-backend/spotbugs-exclude-rules.xml
@@ -3,4 +3,7 @@
     <Match>
         <Bug pattern="CRLF_INJECTION_LOGS"/> <!-- Rule is ignored because JSON-based logging should be used in operation via the Spring profile json-logging, see https://refarch-templates.oss.muenchen.de/getting-started.html#profiles for more information -->
     </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/> <!-- Rule is ignored because spring uses dependency injection. The classes that are injected will be managed by Spring, meaning they do not need to be immutable. See https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html -->
+    </Match>
 </FindBugsFilter>

--- a/refarch-eai/spotbugs-exclude-rules.xml
+++ b/refarch-eai/spotbugs-exclude-rules.xml
@@ -3,4 +3,7 @@
     <Match>
         <Bug pattern="CRLF_INJECTION_LOGS"/> <!-- Rule is ignored because JSON-based logging should be used in operation via the Spring profile json-logging, see https://refarch-templates.oss.muenchen.de/getting-started.html#profiles for more information -->
     </Match>
+    <Match>
+        <Bug pattern="EI_EXPOSE_REP2"/> <!-- Rule is ignored because spring uses dependency injection. The classes that are injected will be managed by Spring, meaning they do not need to be immutable. See https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html -->
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch-templates.oss.muenchen.de/document.html#writing-the-documentation
[code-quality-link]: https://refarch-templates.oss.muenchen.de/develop.html#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose

## Changes

- removed the lombok config
- removed expose_rep spotbugs rule

## Reference

Issue: #545 

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed legacy configuration settings related to automated code generation and warning suppression.
  - Updated static analysis rules to better accommodate dependency injection practices, reducing unnecessary alerts during code reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->