### PR TITLE
Enable JSON-based logging by default

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -77,11 +77,13 @@ Congratulations, the Backend/EAI is now ready to use.
 
 By default, the template supports two Maven profiles:
 
-- `local`: Contains the necessary configurations for running the application.
-  locally, including settings for ports, SSO, and the database
+- `local`: Contains the necessary configurations for running the application locally, including settings for ports, SSO, and the database.
 - `no-security`: Configured to operate without security measures for development.
   or testing purposes.
-- `json-logging`: Switches logging from textual to JSON output (only relevant when deployed).
+
+::: info Information
+When running with the `local` profile, text-based logging is used (instead of JSON-based logging). This makes debugging easier during development.
+:::
 
 ## Frontend & Web Components
 

--- a/refarch-backend/spotbugs-exclude-rules.xml
+++ b/refarch-backend/spotbugs-exclude-rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
     <Match>
-        <Bug pattern="CRLF_INJECTION_LOGS"/> <!-- Rule is ignored because JSON-based logging should be used in operation via the Spring profile json-logging, see https://refarch-templates.oss.muenchen.de/getting-started.html#profiles for more information -->
+        <Bug pattern="CRLF_INJECTION_LOGS"/> <!-- Rule is ignored because JSON-based logging is used in operation -->
     </Match>
     <Match>
         <Bug pattern="EI_EXPOSE_REP2"/> <!-- Rule is ignored because spring uses dependency injection. The classes that are injected will be managed by Spring, meaning they do not need to be immutable. See https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html -->

--- a/refarch-backend/src/main/resources/logback-spring.xml
+++ b/refarch-backend/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <springProperty scope="context" name="springAppName" source="spring.application.name"/>
 
 
-    <springProfile name="!json-logging">
+    <springProfile name="local | test">
 
         <!-- Log appender -->
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -48,7 +48,7 @@
     </springProfile>
 
 
-    <springProfile name="json-logging">
+    <springProfile name="!local &amp; !test">
 
         <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">

--- a/refarch-backend/src/test/java/de/muenchen/refarch/TestConstants.java
+++ b/refarch-backend/src/test/java/de/muenchen/refarch/TestConstants.java
@@ -16,8 +16,6 @@ public final class TestConstants {
 
     public static final String SPRING_NO_SECURITY_PROFILE = "no-security";
 
-    public static final String SPRING_JSON_LOGGING_PROFILE = "json-logging";
-
     public static final String TESTCONTAINERS_POSTGRES_IMAGE = "postgres:16.0-alpine3.18";
 
     @NoArgsConstructor

--- a/refarch-backend/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingTest.java
+++ b/refarch-backend/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingTest.java
@@ -1,6 +1,5 @@
 package de.muenchen.refarch.configuration;
 
-import static de.muenchen.refarch.TestConstants.SPRING_JSON_LOGGING_PROFILE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.PrintWriter;
@@ -23,16 +22,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ActiveProfiles;
 
 import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@ActiveProfiles(SPRING_JSON_LOGGING_PROFILE)
 @ExtendWith(OutputCaptureExtension.class)
 @Slf4j
 @Disabled("run manually on logback config changes")
-class LogbackJsonLoggingConfigurationTest {
+class LogbackJsonLoggingTest {
 
     private static final String EXCEPTION_MESSAGE = "EXC_MESSAGE";
     private static final Pattern STACKTRACE_PATTERN = Pattern.compile("stack_trace\":\"([^\"]*)\"");

--- a/refarch-eai/spotbugs-exclude-rules.xml
+++ b/refarch-eai/spotbugs-exclude-rules.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <FindBugsFilter>
     <Match>
-        <Bug pattern="CRLF_INJECTION_LOGS"/> <!-- Rule is ignored because JSON-based logging should be used in operation via the Spring profile json-logging, see https://refarch-templates.oss.muenchen.de/getting-started.html#profiles for more information -->
+        <Bug pattern="CRLF_INJECTION_LOGS"/> <!-- Rule is ignored because JSON-based logging is used in operation -->
     </Match>
     <Match>
         <Bug pattern="EI_EXPOSE_REP2"/> <!-- Rule is ignored because spring uses dependency injection. The classes that are injected will be managed by Spring, meaning they do not need to be immutable. See https://docs.spring.io/spring-framework/reference/core/beans/dependencies/factory-collaborators.html -->

--- a/refarch-eai/src/main/resources/logback-spring.xml
+++ b/refarch-eai/src/main/resources/logback-spring.xml
@@ -8,7 +8,7 @@
     <springProperty scope="context" name="springAppName" source="spring.application.name"/>
 
 
-    <springProfile name="!json-logging">
+    <springProfile name="local | test">
 
         <!-- Log appender -->
         <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
@@ -48,7 +48,7 @@
     </springProfile>
 
 
-    <springProfile name="json-logging">
+    <springProfile name="!local &amp; !test">
 
         <appender name="JSON_STDOUT" class="ch.qos.logback.core.ConsoleAppender">
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">

--- a/refarch-eai/src/test/java/de/muenchen/refarch/TestConstants.java
+++ b/refarch-eai/src/test/java/de/muenchen/refarch/TestConstants.java
@@ -9,6 +9,4 @@ public final class TestConstants {
 
     public static final String SPRING_TEST_PROFILE = "test";
 
-    public static final String SPRING_JSON_LOGGING_PROFILE = "json-logging";
-
 }

--- a/refarch-eai/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingTest.java
+++ b/refarch-eai/src/test/java/de/muenchen/refarch/configuration/LogbackJsonLoggingTest.java
@@ -1,6 +1,5 @@
 package de.muenchen.refarch.configuration;
 
-import static de.muenchen.refarch.TestConstants.SPRING_JSON_LOGGING_PROFILE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.PrintWriter;
@@ -23,16 +22,14 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.test.context.ActiveProfiles;
 
 import lombok.extern.slf4j.Slf4j;
 
 @SpringBootTest(webEnvironment = WebEnvironment.NONE)
-@ActiveProfiles(SPRING_JSON_LOGGING_PROFILE)
 @ExtendWith(OutputCaptureExtension.class)
 @Slf4j
 @Disabled("run manually on logback config changes")
-class LogbackJsonLoggingConfigurationTest {
+class LogbackJsonLoggingTest {
 
     private static final String EXCEPTION_MESSAGE = "EXC_MESSAGE";
     private static final Pattern STACKTRACE_PATTERN = Pattern.compile("stack_trace\":\"([^\"]*)\"");


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch-templates.oss.muenchen.de/document.html#writing-the-documentation
[code-quality-link]: https://refarch-templates.oss.muenchen.de/develop.html#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose

## Changes

- Updated logging configuration to use JSON-based logging by default
- Use text-based logging only for local development and for text execution
- Updated documentation

## Reference

Issue: #827

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)
- [x] Opened follow-up issue in [refarch repository][refarch-create-issue-link] (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated user guides with clearer instructions on profile usage and logging behavior.
  
- **Refactor**
  - Revised logging configurations to enable text-based logging in development and test environments while using JSON logging elsewhere.
  
- **Tests**
  - Streamlined logging tests by removing deprecated settings for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->