### PR TITLE
:memo: Added documentation on how to enable PR splitting by folders

### DIFF
--- a/docs/.markdownlint.jsonc
+++ b/docs/.markdownlint.jsonc
@@ -6,4 +6,5 @@
     "siblings_only": true,
   },
   "line-length": false,
+  "no-inline-html": false,
 }

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -164,12 +164,15 @@ The templates by default make use of a centralized configuration we provide for 
 To modify the default Renovate settings, the `renovate.json5` file in the project's root directory can be edited.
 
 ::: info Information
-To make Renovate work, make sure that it has access to your GitHub repository.
-For projects in the `it-at-m` organization Renovate automatically has access and is enabled when the configuration file is found in your repository.
+By default Renovate creates grouped PRs for dependency bumps. This means that if a particular dependency is found in multiple package manager files, the bump will be applied to all occurrences.
+If you want Renovate to create separate PRs depending on the subfolder, you should add <code v-pre>"additionalBranchPrefix": "{{parentDir}}-"</code> to your Renovate configuration.
+Check the official [Renovate documentation](https://docs.renovatebot.com/configuration-options/#additionalbranchprefix) for further information and configuration options.
 :::
 
 ::: danger IMPORTANT
-To finish the onboarding process of Renovate, you need to open a PR for a dependency update found by Renovate through the "Dependency Dashboard" issue.
+To make Renovate work, make sure that it has access to your GitHub repository.
+For projects in the `it-at-m` organization Renovate has access by default and is enabled when the configuration file is found in your repository.
+However, to finish the onboarding process of Renovate, you need to open a PR for a dependency update found by Renovate through the "Dependency Dashboard" issue.
 This PR then has to be merged manually once.
 After that's done Renovate will start opening PRs automatically.
 :::

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -165,13 +165,13 @@ To modify the default Renovate settings, the `renovate.json5` file in the projec
 
 ::: info Information
 By default Renovate creates grouped PRs for dependency bumps. This means that if a particular dependency is found in multiple package manager files, the bump will be applied to all occurrences.
-If you want Renovate to create separate PRs depending on the subfolder, you should add <code v-pre>"additionalBranchPrefix": "{{parentDir}}-"</code> to your Renovate configuration.
+If you want Renovate to create separate PRs by subfolder, add <code v-pre>"additionalBranchPrefix": "{{parentDir}}-"</code> to your Renovate configuration.
 Check the official [Renovate documentation](https://docs.renovatebot.com/configuration-options/#additionalbranchprefix) for further information and configuration options.
 :::
 
 ::: danger IMPORTANT
 To make Renovate work, make sure that it has access to your GitHub repository.
-For projects in the `it-at-m` organization Renovate has access by default and is enabled when the configuration file is found in your repository.
+For projects in the `it-at-m` organization, Renovate has access by default and is enabled when the configuration file is found in your repository.
 However, to finish the onboarding process of Renovate, you need to open a PR for a dependency update found by Renovate through the "Dependency Dashboard" issue.
 This PR then has to be merged manually once.
 After that's done Renovate will start opening PRs automatically.


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch-templates.oss.muenchen.de/document.html#writing-the-documentation
[code-quality-link]: https://refarch-templates.oss.muenchen.de/develop.html#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose

## Changes

- Added documentation for PR splitting on folder level

## Reference

Issue: #850

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Created / Updated [documentation][documentation-link] (in English)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated dependency management information to clarify grouped updates for multi-file configurations.
  - Introduced guidance for configuring separate update PRs based on subfolder structures.
  - Clarified repository access details and onboarding steps related to dependency updates.
  - Added configuration option to allow inline HTML in markdown files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->