### PR TITLE
fix: SecurityProperties needed when running with no security profile

### DIFF
--- a/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityConfiguration.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityConfiguration.java
@@ -51,7 +51,7 @@ public class SecurityConfiguration {
                         .authenticated())
                 .oauth2ResourceServer(httpSecurityOAuth2ResourceServerConfigurer -> httpSecurityOAuth2ResourceServerConfigurer
                         .jwt(jwtConfigurer -> jwtConfigurer.jwtAuthenticationConverter(new JwtUserInfoAuthenticationConverter(
-                                new UserInfoAuthoritiesService(securityProperties.userInfoUri(), restTemplateBuilder)))));
+                                new UserInfoAuthoritiesService(securityProperties.getUserInfoUri(), restTemplateBuilder)))));
 
         return http.build();
     }

--- a/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityProperties.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityProperties.java
@@ -1,6 +1,8 @@
 package de.muenchen.refarch.configuration;
 
 import de.muenchen.refarch.security.RequestResponseLoggingFilter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.stream.Collectors;
@@ -39,6 +41,7 @@ public class SecurityProperties {
     @NotNull
     private List<AntPathRequestMatcher> loggingIgnoreList = List.of(AntPathRequestMatcher.antMatcher("/actuator/**"));
 
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", matchType = SuppressMatchType.EXACT)
     public List<AntPathRequestMatcher> getLoggingIgnoreListAsMatchers() {
         return loggingIgnoreList;
     }

--- a/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityProperties.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityProperties.java
@@ -1,6 +1,7 @@
 package de.muenchen.refarch.configuration;
 
 import de.muenchen.refarch.security.RequestResponseLoggingFilter;
+import de.muenchen.refarch.security.RequestResponseLoggingFilter.LoggingMode;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import edu.umd.cs.findbugs.annotations.SuppressMatchType;
 import jakarta.validation.constraints.NotBlank;
@@ -26,7 +27,7 @@ public class SecurityProperties {
      * Logging mode for incoming HTTP requests, see also {@link RequestResponseLoggingFilter}
      */
     @NotNull
-    private RequestResponseLoggingFilter.LoggingMode loggingMode = RequestResponseLoggingFilter.LoggingMode.NONE;
+    private LoggingMode loggingMode = LoggingMode.NONE;
 
     /**
      * URI of the userinfo endpoint to use for fetching data relevant for authorization (e.g. roles or

--- a/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityProperties.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/configuration/SecurityProperties.java
@@ -1,11 +1,88 @@
 package de.muenchen.refarch.configuration;
 
+import de.muenchen.refarch.security.RequestResponseLoggingFilter;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import edu.umd.cs.findbugs.annotations.SuppressMatchType;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.validation.annotation.Validated;
 
+import java.util.List;
+
+/**
+ * Properties class that holds configuration data relevant for security mechanisms
+ */
 @ConfigurationProperties(prefix = "security")
 @Validated
-public record SecurityProperties(@NotBlank String requestLogging, @NotBlank String userInfoUri) {
+@Profile("!no-security")
+@NoArgsConstructor
+public class SecurityProperties {
+
+    /**
+     * Logging mode for incoming HTTP requests, see also {@link RequestResponseLoggingFilter}
+     */
+    @NotNull
+    @Setter
+    @Getter
+    @SuppressWarnings("PMD.UnusedAssignment")
+    private RequestResponseLoggingFilter.LoggingMode loggingMode = RequestResponseLoggingFilter.LoggingMode.NONE;
+
+    /**
+     * URI of the userinfo endpoint to use for fetching data relevant for authorization (e.g. roles or
+     * authorities), see also {@link UserInfoAuthoritiesService}
+     */
+    @NotBlank
+    @Setter
+    @Getter
+    private String userInfoUri;
+
+    /**
+     * List of paths to ignore when logging HTTP requests, see also {@link RequestResponseLoggingFilter}
+     */
+    @NotNull
+    @SuppressWarnings("PMD.UnusedAssignment")
+    private List<String> loggingIgnoreList = List.of("/actuator/**");
+
+    /**
+     * Internal matcher representation of the provided {@link #loggingIgnoreList}
+     */
+    private List<AntPathRequestMatcher> loggingIgnoreListAsMatchers = null;
+
+    @SuppressWarnings("unused")
+    public SecurityProperties(final RequestResponseLoggingFilter.LoggingMode loggingMode, final String userInfoUri, final List<String> loggingIgnoreList) {
+        this.loggingMode = loggingMode;
+        this.userInfoUri = userInfoUri;
+        this.loggingIgnoreList = loggingIgnoreList;
+    }
+
+    /**
+     * Sets the logging ignore list and updates the internal matcher representation
+     *
+     * @param loggingIgnoreList ignore list to set
+     */
+    @SuppressWarnings("PMD.NullAssignment")
+    public void setLoggingIgnoreList(final List<String> loggingIgnoreList) {
+        this.loggingIgnoreList = loggingIgnoreList;
+        this.loggingIgnoreListAsMatchers = null;
+    }
+
+    /**
+     * Getter for the internal matcher representation implemented as singleton
+     *
+     * @return matcher representations
+     */
+    @SuppressFBWarnings(value = "EI_EXPOSE_REP", matchType = SuppressMatchType.EXACT)
+    public List<AntPathRequestMatcher> getLoggingIgnoreListAsMatchers() {
+        if (loggingIgnoreListAsMatchers == null) {
+            loggingIgnoreListAsMatchers = loggingIgnoreList.stream().map(AntPathRequestMatcher::antMatcher).toList();
+        }
+        return loggingIgnoreListAsMatchers;
+    }
 
 }

--- a/refarch-backend/src/main/java/de/muenchen/refarch/security/RequestResponseLoggingFilter.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/security/RequestResponseLoggingFilter.java
@@ -101,13 +101,17 @@ public class RequestResponseLoggingFilter implements Filter {
      * @return True if logging should be done otherwise false.
      */
     private boolean checkForLogging(final HttpServletRequest httpServletRequest) {
-        final boolean isAllowedPath = securityProperties.getLoggingIgnoreListAsMatchers().stream().noneMatch(matcher -> matcher.matches(httpServletRequest));
-        final boolean isAllowedMethod = switch (securityProperties.getLoggingMode()) {
+        // check ignored paths
+        final boolean isIgnoredPath = securityProperties.getLoggingIgnoreListAsMatchers().stream().anyMatch(matcher -> matcher.matches(httpServletRequest));
+        if (isIgnoredPath) {
+            return false;
+        }
+        // check logging mode
+        return switch (securityProperties.getLoggingMode()) {
         case LoggingMode.ALL -> true;
         case LoggingMode.CHANGING -> CHANGING_METHODS.contains(httpServletRequest.getMethod());
         default -> false;
         };
-        return isAllowedPath && isAllowedMethod;
     }
 
 }

--- a/refarch-backend/src/main/java/de/muenchen/refarch/security/RequestResponseLoggingFilter.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/security/RequestResponseLoggingFilter.java
@@ -15,7 +15,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.stereotype.Component;
 
@@ -27,18 +29,34 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @RequiredArgsConstructor
 @ToString
+@Profile("!no-security")
 public class RequestResponseLoggingFilter implements Filter {
 
-    private static final String REQUEST_LOGGING_MODE_ALL = "all";
-
-    private static final String REQUEST_LOGGING_MODE_CHANGING = "changing";
-
-    private static final List<String> CHANGING_METHODS = Arrays.asList("POST", "PUT", "PATCH", "DELETE");
+    private static final List<String> CHANGING_METHODS = Arrays.asList(HttpMethod.POST.name(), HttpMethod.PUT.name(), HttpMethod.PATCH.name(),
+            HttpMethod.DELETE.name());
 
     /**
      * The property or a zero length string if no property is available.
      */
     private final SecurityProperties securityProperties;
+
+    /**
+     * Logging mode to use for incoming HTTP requests
+     */
+    public enum LoggingMode {
+        /**
+         * Logs all requests
+         */
+        ALL,
+        /**
+         * Logs only changing requests, see {@link RequestResponseLoggingFilter#CHANGING_METHODS}
+         */
+        CHANGING,
+        /**
+         * Logs no requests
+         */
+        NONE
+    }
 
     /**
      * {@inheritDoc}
@@ -83,9 +101,13 @@ public class RequestResponseLoggingFilter implements Filter {
      * @return True if logging should be done otherwise false.
      */
     private boolean checkForLogging(final HttpServletRequest httpServletRequest) {
-        return REQUEST_LOGGING_MODE_ALL.equals(securityProperties.requestLogging())
-                || (REQUEST_LOGGING_MODE_CHANGING.equals(securityProperties.requestLogging())
-                        && CHANGING_METHODS.contains(httpServletRequest.getMethod()));
+        final boolean isAllowedPath = securityProperties.getLoggingIgnoreListAsMatchers().stream().noneMatch(matcher -> matcher.matches(httpServletRequest));
+        final boolean isAllowedMethod = switch (securityProperties.getLoggingMode()) {
+        case LoggingMode.ALL -> true;
+        case LoggingMode.CHANGING -> CHANGING_METHODS.contains(httpServletRequest.getMethod());
+        default -> false;
+        };
+        return isAllowedPath && isAllowedMethod;
     }
 
 }

--- a/refarch-backend/src/main/java/de/muenchen/refarch/security/RequestResponseLoggingFilter.java
+++ b/refarch-backend/src/main/java/de/muenchen/refarch/security/RequestResponseLoggingFilter.java
@@ -101,17 +101,13 @@ public class RequestResponseLoggingFilter implements Filter {
      * @return True if logging should be done otherwise false.
      */
     private boolean checkForLogging(final HttpServletRequest httpServletRequest) {
-        // check ignored paths
-        final boolean isIgnoredPath = securityProperties.getLoggingIgnoreListAsMatchers().stream().anyMatch(matcher -> matcher.matches(httpServletRequest));
-        if (isIgnoredPath) {
-            return false;
-        }
-        // check logging mode
-        return switch (securityProperties.getLoggingMode()) {
+        final boolean isLoggingMode = switch (securityProperties.getLoggingMode()) {
         case LoggingMode.ALL -> true;
         case LoggingMode.CHANGING -> CHANGING_METHODS.contains(httpServletRequest.getMethod());
         default -> false;
         };
+
+        return isLoggingMode && securityProperties.getLoggingIgnoreListAsMatchers().stream().noneMatch(matcher -> matcher.matches(httpServletRequest));
     }
 
 }

--- a/refarch-backend/src/main/resources/application-local.yml
+++ b/refarch-backend/src/main/resources/application-local.yml
@@ -21,6 +21,8 @@ spring:
       resourceserver:
         jwt:
           jwk-set-uri: ${sso.url}/auth/realms/${sso.realm}/protocol/openid-connect/certs
+          # adds audience verification - https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#_supplying_audiences
+          # requires client to be in audience claim, see https://www.keycloak.org/docs/latest/server_admin/#_audience_resolve
           audiences:
             - ${sso.client}
 
@@ -32,6 +34,5 @@ sso:
   client: local
 
 security:
-  # possible values: none, all, changing (With changing, only changing requests such as POST, PUT, DELETE are logged)
-  requestLogging: all
-  userInfoUri: ${sso.url}/auth/realms/${sso.realm}/protocol/openid-connect/userinfo
+  user-info-uri: ${sso.url}/auth/realms/${sso.realm}/protocol/openid-connect/userinfo
+  logging-mode: all

--- a/refarch-backend/src/main/resources/application.yml
+++ b/refarch-backend/src/main/resources/application.yml
@@ -12,15 +12,6 @@ spring:
   flyway:
     locations:
       - classpath:db/migration/schema
-  security:
-    oauth2:
-      resourceserver:
-        jwt:
-          audiences:
-          # adds audience verification - https://docs.spring.io/spring-security/reference/servlet/oauth2/resource-server/jwt.html#_supplying_audiences
-          # requires client to be in audience claim, see https://www.keycloak.org/docs/latest/server_admin/#_audience_resolve
-          # TODO - should be the clientId of the actual project
-          - refarch
 
 server:
   error:


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[documentation-link]: https://refarch-templates.oss.muenchen.de/document.html#writing-the-documentation
[code-quality-link]: https://refarch-templates.oss.muenchen.de/develop.html#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose

## Changes

- Removed audience configuration by default
- Updated property names
- Added ignoreList functionality to RequestResponseLoggingFilter
- Disabled RequestResponseLoggingFilter in no-security mode

## Reference

Issue: #883

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced configurable logging modes with options for comprehensive or selective request logging.

- **Refactor**
  - Enhanced security configuration for improved flexibility and reliability.
  - Restructured the `SecurityProperties` class for better configuration management.
  - Added a new `LoggingMode` enum to define logging behavior.

- **Chores**
  - Updated configuration settings by renaming keys and removing deprecated OAuth2 JWT configurations.
  - Added comments for clarity in the configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->