### PR TITLE
fix: Snackbar timeout for error messages

### DIFF
--- a/refarch-frontend/src/components/TheSnackbar.vue
+++ b/refarch-frontend/src/components/TheSnackbar.vue
@@ -43,7 +43,7 @@ watch(
   () => {
     color.value = snackbarStore.level;
     if (color.value === STATUS_INDICATORS.ERROR) {
-      timeout.value = 0;
+      timeout.value = -1;
     } else {
       timeout.value = SNACKBAR_DEFAULT_TIMEOUT;
     }


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- TheSnackbar.vue - set timeout to -1 for ERROR messages

## Reference

Issue: #969

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English
- [x] Removed waste on branch (e.g. `console.log`), see [code quality tooling][code-quality-link]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Error notifications now remain visible until manually dismissed, ensuring important messages are not missed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->