### PR TITLE
Feature: Enable vuetify auto imports

### DIFF
--- a/refarch-frontend/src/App.vue
+++ b/refarch-frontend/src/App.vue
@@ -79,23 +79,6 @@ import { mdiApps, mdiMagnify } from "@mdi/js";
 import { AppSwitcher } from "@muenchen/appswitcher-vue";
 import { useToggle } from "@vueuse/core";
 import { onMounted, ref } from "vue";
-import {
-  VApp,
-  VAppBar,
-  VAppBarNavIcon,
-  VBtn,
-  VCol,
-  VContainer,
-  VFadeTransition,
-  VList,
-  VListItem,
-  VListItemTitle,
-  VMain,
-  VNavigationDrawer,
-  VRow,
-  VTextField,
-  VToolbarTitle,
-} from "vuetify/components";
 
 import { getUser } from "@/api/user-client";
 import Ad2ImageAvatar from "@/components/common/Ad2ImageAvatar.vue";

--- a/refarch-frontend/src/components/TheSnackbar.vue
+++ b/refarch-frontend/src/components/TheSnackbar.vue
@@ -19,7 +19,6 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
-import { VBtn, VSnackbar } from "vuetify/components";
 
 import { SNACKBAR_DEFAULT_TIMEOUT, STATUS_INDICATORS } from "@/constants";
 import { useSnackbarStore } from "@/stores/snackbar";

--- a/refarch-frontend/src/components/common/Ad2ImageAvatar.vue
+++ b/refarch-frontend/src/components/common/Ad2ImageAvatar.vue
@@ -8,7 +8,6 @@
 </template>
 <script setup lang="ts">
 import { computed } from "vue";
-import { VAvatar } from "vuetify/components";
 
 import { DefaultLhmAvatarService } from "@/api/ad2image-avatar-client";
 

--- a/refarch-frontend/src/components/common/YesNoDialog.vue
+++ b/refarch-frontend/src/components/common/YesNoDialog.vue
@@ -53,17 +53,6 @@
 </template>
 
 <script setup lang="ts">
-import {
-  VBtn,
-  VCard,
-  VCardActions,
-  VCardText,
-  VCardTitle,
-  VDialog,
-  VIcon,
-  VSpacer,
-} from "vuetify/components";
-
 /**
  * The YesNo dialog is a generic dialog for yes/no queries to the user.
  * For example, it can be used to confirm the deletion of an entity.

--- a/refarch-frontend/src/views/GetStartedView.vue
+++ b/refarch-frontend/src/views/GetStartedView.vue
@@ -36,7 +36,6 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
-import { VCol, VContainer, VRow } from "vuetify/components";
 
 import YesNoDialog from "@/components/common/YesNoDialog.vue";
 import { useSaveLeave } from "@/composables/saveLeave";

--- a/refarch-frontend/src/views/HomeView.vue
+++ b/refarch-frontend/src/views/HomeView.vue
@@ -24,7 +24,6 @@
 
 <script setup lang="ts">
 import { onMounted, ref } from "vue";
-import { VCol, VContainer, VImg, VRow } from "vuetify/components";
 
 import { checkHealth } from "@/api/health-client";
 import { useSnackbarStore } from "@/stores/snackbar";

--- a/refarch-frontend/tests/unit/example.spec.ts
+++ b/refarch-frontend/tests/unit/example.spec.ts
@@ -1,6 +1,6 @@
 import { shallowMount } from "@vue/test-utils";
 import { createPinia } from "pinia";
-import { beforeAll, beforeEach, describe, expect, test } from "vitest";
+import { describe, expect, test } from "vitest";
 import { createVuetify } from "vuetify";
 import * as components from "vuetify/components";
 import * as directives from "vuetify/directives";
@@ -8,22 +8,12 @@ import * as directives from "vuetify/directives";
 import TheSnackbar from "@/components/TheSnackbar.vue";
 
 const pinia = createPinia();
+const vuetify = createVuetify({
+  components,
+  directives,
+});
 
 describe("TheSnackbar.vue", () => {
-  let vuetify: ReturnType<typeof createVuetify>;
-
-  beforeAll(() => {
-    createPinia();
-    createVuetify();
-  });
-
-  beforeEach(() => {
-    vuetify = createVuetify({
-      components,
-      directives,
-    });
-  });
-
   test("renders props.message when passed", () => {
     const message = "Hello_World";
     const wrapper = shallowMount(TheSnackbar, {

--- a/refarch-frontend/vite.config.ts
+++ b/refarch-frontend/vite.config.ts
@@ -18,9 +18,7 @@ export default defineConfig(({ mode }) => {
           optionsAPI: isDevelopment,
         },
       }),
-      vuetify({
-        autoImport: false,
-      }),
+      vuetify(),
       UnpluginFonts({
         fontsource: {
           families: [


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Enabled Vuetify auto import
- Removed explicit Vuetify imports
- Fixed example test file (due to redundant vuetify instantiations)

## Reference

Issue: #926

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] ~~I have read the Contribution Guidelines (TBD)~~
- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Opened documentation issue in [refarch repository][refarch-create-documentation-issue-link] (if applicable) -> https://github.com/it-at-m/refarch/pull/517

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified component imports by removing explicit Vuetify component imports across multiple files.
  - Streamlined Vuetify plugin configuration for the build process.
  - Optimized test setup by reducing redundant plugin instantiations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->