### PR TITLE
fix(backend): permissions uri property only required if permissions used

### DIFF
--- a/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
+++ b/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.cache.Cache;
@@ -34,7 +33,6 @@ import org.springframework.web.client.RestTemplate;
  * The usage of simpler {@link KeycloakRolesAuthoritiesConverter} should be preferred.
  */
 @Slf4j
-@RequiredArgsConstructor
 public final class KeycloakPermissionsAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
 
     private static final String AUTHENTICATION_CACHE_NAME = "authentication_cache";
@@ -50,7 +48,8 @@ public final class KeycloakPermissionsAuthoritiesConverter implements Converter<
     private final RestTemplate restTemplate;
     private final Cache cache;
 
-    public KeycloakPermissionsAuthoritiesConverter(final SecurityProperties securityProperties, final RestTemplateBuilder restTemplateBuilder) {
+    public KeycloakPermissionsAuthoritiesConverter(final SecurityProperties securityProperties,
+                                                   final RestTemplateBuilder restTemplateBuilder) {
         this(
                 securityProperties,
                 restTemplateBuilder.build(),
@@ -61,9 +60,17 @@ public final class KeycloakPermissionsAuthoritiesConverter implements Converter<
                                 .expireAfterWrite(securityProperties.getPermissionsCacheLifetime())
                                 .ticker(Ticker.systemTicker())
                                 .build()));
+    }
+
+    public KeycloakPermissionsAuthoritiesConverter(final SecurityProperties securityProperties,
+                                                   final RestTemplate restTemplate,
+                                                   final Cache cache) {
         if (!StringUtils.hasText(securityProperties.getPermissionsUri())) {
             throw new IllegalArgumentException("refarch.security.permissions-uri is required for resolving permissions");
         }
+        this.securityProperties = securityProperties;
+        this.restTemplate = restTemplate;
+        this.cache = cache;
     }
 
     /**

--- a/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
+++ b/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
@@ -49,7 +49,7 @@ public final class KeycloakPermissionsAuthoritiesConverter implements Converter<
     private final Cache cache;
 
     public KeycloakPermissionsAuthoritiesConverter(final SecurityProperties securityProperties,
-                                                   final RestTemplateBuilder restTemplateBuilder) {
+            final RestTemplateBuilder restTemplateBuilder) {
         this(
                 securityProperties,
                 restTemplateBuilder.build(),
@@ -63,8 +63,8 @@ public final class KeycloakPermissionsAuthoritiesConverter implements Converter<
     }
 
     public KeycloakPermissionsAuthoritiesConverter(final SecurityProperties securityProperties,
-                                                   final RestTemplate restTemplate,
-                                                   final Cache cache) {
+            final RestTemplate restTemplate,
+            final Cache cache) {
         if (!StringUtils.hasText(securityProperties.getPermissionsUri())) {
             throw new IllegalArgumentException("refarch.security.permissions-uri is required for resolving permissions");
         }

--- a/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
+++ b/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
@@ -23,6 +23,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -60,6 +61,9 @@ public class KeycloakPermissionsAuthoritiesConverter implements Converter<Jwt, C
                                 .expireAfterWrite(securityProperties.getPermissionsCacheLifetime())
                                 .ticker(Ticker.systemTicker())
                                 .build()));
+        if (!StringUtils.hasText(securityProperties.getPermissionsUri())) {
+            throw new IllegalArgumentException("refarch.security.permissions-uri is required for resolving permissions");
+        }
     }
 
     /**

--- a/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
+++ b/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/KeycloakPermissionsAuthoritiesConverter.java
@@ -35,7 +35,7 @@ import org.springframework.web.client.RestTemplate;
  */
 @Slf4j
 @RequiredArgsConstructor
-public class KeycloakPermissionsAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
+public final class KeycloakPermissionsAuthoritiesConverter implements Converter<Jwt, Collection<GrantedAuthority>> {
 
     private static final String AUTHENTICATION_CACHE_NAME = "authentication_cache";
 

--- a/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/SecurityProperties.java
+++ b/backend/src/main/java/de/muenchen/oss/refarch/backend/configuration/security/SecurityProperties.java
@@ -32,7 +32,7 @@ public class SecurityProperties {
      * URI of the endpoint used for fetching permissions,
      * see also {@link KeycloakPermissionsAuthoritiesConverter}.
      */
-    @NotBlank private String permissionsUri;
+    private String permissionsUri;
 
     /**
      * Timeout for which resolved permissions are cached and reused. Default 60s.


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- fix(backend): make SecurityProperties permissions-uri only required if permissions are enabled

## Reference

Issue: closes #1444
https://git.muenchen.de/ccse/refarch/refarch-iac/-/work_items/8

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security configuration validation to prevent the system from initializing with invalid permission settings, ensuring clear error messages when required configuration is missing.

* **Chores**
  * Updated internal security class structure to restrict subclassing and consolidate configuration validation logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->