### PR TITLE
chore(eai): rm value property

### DIFF
--- a/eai/src/main/java/de/muenchen/oss/refarch/eai/EaiRouteBuilder.java
+++ b/eai/src/main/java/de/muenchen/oss/refarch/eai/EaiRouteBuilder.java
@@ -3,15 +3,11 @@ package de.muenchen.oss.refarch.eai;
 import lombok.RequiredArgsConstructor;
 import org.apache.camel.LoggingLevel;
 import org.apache.camel.builder.RouteBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class EaiRouteBuilder extends RouteBuilder {
-
-    @Value("${output}")
-    private String outputRoute;
 
     public static final String DIRECT_ROUTE = "direct:eai-route";
 
@@ -23,7 +19,7 @@ public class EaiRouteBuilder extends RouteBuilder {
                 .routeId("eai-route")
                 .log(LoggingLevel.DEBUG, "de.muenchen",
                         "Add camel routing... (https://camel.apache.org/components/latest/eips/enterprise-integration-patterns.html).")
-                .to(outputRoute);
+                .to("mock:example");
     }
 
 }

--- a/eai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/eai/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,5 +1,0 @@
-{"properties": [{
-  "name": "output",
-  "type": "java.lang.String",
-  "description": "A description for 'output'"
-}]}

--- a/eai/src/main/resources/application.yml
+++ b/eai/src/main/resources/application.yml
@@ -76,6 +76,3 @@ camel:
   servlet:
     mapping:
       context-path: /api/*
-
-# Custom properties
-output: direct:foo

--- a/eai/src/test/java/de/muenchen/oss/refarch/eai/EaiTest.java
+++ b/eai/src/test/java/de/muenchen/oss/refarch/eai/EaiTest.java
@@ -24,7 +24,7 @@ class EaiTest {
     @Produce(EaiRouteBuilder.DIRECT_ROUTE)
     private ProducerTemplate producer;
 
-    @EndpointInject("mock:output")
+    @EndpointInject("mock:example")
     private MockEndpoint output;
 
     @Test
@@ -35,7 +35,7 @@ class EaiTest {
         producer.sendBody(message);
 
         output.assertIsSatisfied();
-        assertEquals(message, output.getExchanges().get(0).getMessage().getBody(String.class));
+        assertEquals(message, output.getExchanges().getFirst().getMessage().getBody(String.class));
     }
 
 }

--- a/eai/src/test/resources/application-test.yml
+++ b/eai/src/test/resources/application-test.yml
@@ -12,6 +12,3 @@ logging:
 camel:
   main:
     tracing: false
-
-# Custom properties
-output : mock:output


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- chore(eai): rm `@Value` property to only use ConfigurationProperties in the refarch-templates

## Reference

Issue: closes #106

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed the configurable output endpoint. The application now uses a hardcoded output target instead of reading from configuration.

* **Chores**
  * Removed unused configuration property declarations and metadata files.
  * Updated tests to reflect the new output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->