### PR TITLE
Maintenance: Download OpenAPI with Maven

### DIFF
--- a/frontend/download-openapi-jar.bat
+++ b/frontend/download-openapi-jar.bat
@@ -1,6 +1,14 @@
 @echo off
 echo Starting download script in GitBash...
 
+REM Check if bash is available
+where bash >nul 2>&1
+if errorlevel 1 (
+    echo Error: bash was not found. Please install Git Bash or add it to your PATH.
+    pause
+    exit /b 1
+)
+
 REM change to directory of this .bat-file
 cd /d "%~dp0"
 

--- a/frontend/download-openapi-jar.sh
+++ b/frontend/download-openapi-jar.sh
@@ -52,8 +52,8 @@ fi
 echo " => Downloading .jar file using Maven:"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
-mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=$DIR
-mv $DIR/$REMOTE_JAR $DIR/$LOCAL_JAR
+mvn dependency:copy "-Dartifact=org.openapitools:openapi-generator-cli:$VER:jar" "-DoutputDirectory=$DIR"
+mv "$DIR/$REMOTE_JAR" "$DIR/$LOCAL_JAR"
 
 echo " => Download completed"
 echo "----------------------------------------"

--- a/frontend/download-openapi-jar.sh
+++ b/frontend/download-openapi-jar.sh
@@ -6,7 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 echo "Starting download script ..."
 
-
 echo "----------------------------------------"
 echo "Project: $SCRIPT_DIR"
 
@@ -36,6 +35,7 @@ LOCAL_JAR="$VER.jar"
 DIR="$SCRIPT_DIR/node_modules/@openapitools/openapi-generator-cli/versions"
 mkdir -p "$DIR"
 
+# Check if jar file already exists
 if [ -f "$DIR/$LOCAL_JAR" ]; then
   echo " => .jar file already exists: $DIR/$LOCAL_JAR, skipping download."
   echo "----------------------------------------"
@@ -43,11 +43,17 @@ if [ -f "$DIR/$LOCAL_JAR" ]; then
   exit 0
 fi
 
-echo " => Downloading .jar file:"
+# Check if mvn is available
+if ! command -v mvn > /dev/null 2>&1; then
+  echo "Error: Maven (mvn) is not installed or not in PATH but required for downloading."
+  exit 1
+fi
+
+echo " => Downloading .jar file using Maven:"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
-mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=.
-mv $REMOTE_JAR $DIR/$LOCAL_JAR
+mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=$DIR
+mv $DIR/$REMOTE_JAR $DIR/$LOCAL_JAR
 
 echo " => Download completed"
 echo "----------------------------------------"

--- a/frontend/download-openapi-jar.sh
+++ b/frontend/download-openapi-jar.sh
@@ -44,7 +44,6 @@ if [ -f "$DIR/$LOCAL_JAR" ]; then
 fi
 
 echo " => Downloading .jar file:"
-echo "    URL:        $URL"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
 mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=.

--- a/frontend/download-openapi-jar.sh
+++ b/frontend/download-openapi-jar.sh
@@ -6,33 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 echo "Starting download script ..."
 
-set_proxy_from_global_npmrc() {
-  local GLOBAL_NPMRC
-  GLOBAL_NPMRC=$(npm config get userconfig 2>/dev/null || echo "")
-  [ -n "$GLOBAL_NPMRC" ] && [ -f "$GLOBAL_NPMRC" ] || return 0
-
-  echo "Reading proxy-configuration from global .npmrc: $GLOBAL_NPMRC"
-
-  unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
-
-  local P HP
-  P=$(grep -E '^[[:space:]]*proxy=' "$GLOBAL_NPMRC"        | tail -n1 | cut -d'=' -f2- || true)
-  HP=$(grep -E '^[[:space:]]*https-proxy=' "$GLOBAL_NPMRC" | tail -n1 | cut -d'=' -f2- || true)
-
-  if [ -n "$P" ]; then
-    export http_proxy="$P" HTTP_PROXY="$P"
-    echo " => set http_proxy to: $P"
-  fi
-  if [ -n "$HP" ]; then
-    export https_proxy="$HP" HTTPS_PROXY="$HP"
-    echo " => set https_proxy to: $HP"
-  fi
-  if [ -z "$P" ] && [ -z "$HP" ]; then
-    echo " => No proxy-configuration found in .npmrc"
-  fi
-}
-
-set_proxy_from_global_npmrc
 
 echo "----------------------------------------"
 echo "Project: $SCRIPT_DIR"
@@ -57,7 +30,6 @@ echo " => Selected version in config-file: $VER"
 
 # Remote filename and location of jar
 REMOTE_JAR="openapi-generator-cli-$VER.jar"
-URL="https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$VER/$REMOTE_JAR"
 
 # Local desired filename and location
 LOCAL_JAR="$VER.jar"
@@ -75,13 +47,8 @@ echo " => Downloading .jar file:"
 echo "    URL:        $URL"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
-if command -v curl >/dev/null 2>&1; then
-  echo "  => Using curl"
-  curl -fSL "$URL" -o "$DIR/$LOCAL_JAR"
-else
-  echo "  => Using wget"
-  wget -O "$DIR/$LOCAL_JAR" "$URL"
-fi
+mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=.
+mv $REMOTE_JAR $DIR/$LOCAL_JAR
 
 echo " => Download completed"
 echo "----------------------------------------"

--- a/frontend/download-openapi-jar.sh
+++ b/frontend/download-openapi-jar.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "Starting download script ..."
 
 echo "----------------------------------------"
-echo "Project: $SCRIPT_DIR"
 
 # Reading version number of openapi-config file
 CFG="$SCRIPT_DIR/openapitools.json"
@@ -25,7 +24,7 @@ if [ -z "${VER:-}" ]; then
   exit 1
 fi
 
-echo " => Selected version in config-file: $VER"
+echo "Selected version in config-file: $VER"
 
 # Remote filename and location of jar
 REMOTE_JAR="openapi-generator-cli-$VER.jar"
@@ -37,7 +36,7 @@ mkdir -p "$DIR"
 
 # Check if jar file already exists
 if [ -f "$DIR/$LOCAL_JAR" ]; then
-  echo " => .jar file already exists: $DIR/$LOCAL_JAR, skipping download."
+  echo ".jar file already exists: $DIR/$LOCAL_JAR, skipping download."
   echo "----------------------------------------"
   echo "Done ..."
   exit 0
@@ -49,12 +48,12 @@ if ! command -v mvn > /dev/null 2>&1; then
   exit 1
 fi
 
-echo " => Downloading .jar file using Maven:"
-echo "    Target-file: $DIR/$LOCAL_JAR"
+echo "Downloading .jar file using Maven..."
 
-mvn dependency:copy "-Dartifact=org.openapitools:openapi-generator-cli:$VER:jar" "-DoutputDirectory=$DIR"
+mvn dependency:copy "-Dartifact=org.openapitools:openapi-generator-cli:$VER:jar" "-DoutputDirectory=$DIR" 1>/dev/null
 mv "$DIR/$REMOTE_JAR" "$DIR/$LOCAL_JAR"
 
-echo " => Download completed"
+echo "Download completed"
+echo "File downloaded to $DIR/$LOCAL_JAR"
 echo "----------------------------------------"
 echo "Done ..."

--- a/webcomponent/download-openapi-jar.bat
+++ b/webcomponent/download-openapi-jar.bat
@@ -1,6 +1,14 @@
 @echo off
 echo Starting download script in GitBash...
 
+REM Check if bash is available
+where bash >nul 2>&1
+if errorlevel 1 (
+    echo Error: bash was not found. Please install Git Bash or add it to your PATH.
+    pause
+    exit /b 1
+)
+
 REM change to directory of this .bat-file
 cd /d "%~dp0"
 

--- a/webcomponent/download-openapi-jar.sh
+++ b/webcomponent/download-openapi-jar.sh
@@ -6,33 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 echo "Starting download script ..."
 
-set_proxy_from_global_npmrc() {
-  local GLOBAL_NPMRC
-  GLOBAL_NPMRC=$(npm config get userconfig 2>/dev/null || echo "")
-  [ -n "$GLOBAL_NPMRC" ] && [ -f "$GLOBAL_NPMRC" ] || return 0
-
-  echo "Reading proxy-configuration from global .npmrc: $GLOBAL_NPMRC"
-
-  unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
-
-  local P HP
-  P=$(grep -E '^[[:space:]]*proxy=' "$GLOBAL_NPMRC"        | tail -n1 | cut -d'=' -f2- || true)
-  HP=$(grep -E '^[[:space:]]*https-proxy=' "$GLOBAL_NPMRC" | tail -n1 | cut -d'=' -f2- || true)
-
-  if [ -n "$P" ]; then
-    export http_proxy="$P" HTTP_PROXY="$P"
-    echo " => set http_proxy to: $P"
-  fi
-  if [ -n "$HP" ]; then
-    export https_proxy="$HP" HTTPS_PROXY="$HP"
-    echo " => set https_proxy to: $HP"
-  fi
-  if [ -z "$P" ] && [ -z "$HP" ]; then
-    echo " => No proxy-configuration found in .npmrc"
-  fi
-}
-
-set_proxy_from_global_npmrc
 
 echo "----------------------------------------"
 echo "Project: $SCRIPT_DIR"
@@ -57,7 +30,6 @@ echo " => Selected version in config-file: $VER"
 
 # Remote filename and location of jar
 REMOTE_JAR="openapi-generator-cli-$VER.jar"
-URL="https://repo1.maven.org/maven2/org/openapitools/openapi-generator-cli/$VER/$REMOTE_JAR"
 
 # Local desired filename and location
 LOCAL_JAR="$VER.jar"
@@ -72,16 +44,10 @@ if [ -f "$DIR/$LOCAL_JAR" ]; then
 fi
 
 echo " => Downloading .jar file:"
-echo "    URL:        $URL"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
-if command -v curl >/dev/null 2>&1; then
-  echo "  => Using curl"
-  curl -fSL "$URL" -o "$DIR/$LOCAL_JAR"
-else
-  echo "  => Using wget"
-  wget -O "$DIR/$LOCAL_JAR" "$URL"
-fi
+mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=.
+mv $REMOTE_JAR $DIR/$LOCAL_JAR
 
 echo " => Download completed"
 echo "----------------------------------------"

--- a/webcomponent/download-openapi-jar.sh
+++ b/webcomponent/download-openapi-jar.sh
@@ -52,8 +52,8 @@ fi
 echo " => Downloading .jar file using Maven:"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
-mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=$DIR
-mv $DIR/$REMOTE_JAR $DIR/$LOCAL_JAR
+mvn dependency:copy "-Dartifact=org.openapitools:openapi-generator-cli:$VER:jar" "-DoutputDirectory=$DIR"
+mv "$DIR/$REMOTE_JAR" "$DIR/$LOCAL_JAR"
 
 echo " => Download completed"
 echo "----------------------------------------"

--- a/webcomponent/download-openapi-jar.sh
+++ b/webcomponent/download-openapi-jar.sh
@@ -6,7 +6,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 echo "Starting download script ..."
 
-
 echo "----------------------------------------"
 echo "Project: $SCRIPT_DIR"
 
@@ -36,6 +35,7 @@ LOCAL_JAR="$VER.jar"
 DIR="$SCRIPT_DIR/node_modules/@openapitools/openapi-generator-cli/versions"
 mkdir -p "$DIR"
 
+# Check if jar file already exists
 if [ -f "$DIR/$LOCAL_JAR" ]; then
   echo " => .jar file already exists: $DIR/$LOCAL_JAR, skipping download."
   echo "----------------------------------------"
@@ -43,11 +43,17 @@ if [ -f "$DIR/$LOCAL_JAR" ]; then
   exit 0
 fi
 
-echo " => Downloading .jar file:"
+# Check if mvn is available
+if ! command -v mvn > /dev/null 2>&1; then
+  echo "Error: Maven (mvn) is not installed or not in PATH but required for downloading."
+  exit 1
+fi
+
+echo " => Downloading .jar file using Maven:"
 echo "    Target-file: $DIR/$LOCAL_JAR"
 
-mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=.
-mv $REMOTE_JAR $DIR/$LOCAL_JAR
+mvn dependency:copy -Dartifact=org.openapitools:openapi-generator-cli:$VER:jar -DoutputDirectory=$DIR
+mv $DIR/$REMOTE_JAR $DIR/$LOCAL_JAR
 
 echo " => Download completed"
 echo "----------------------------------------"

--- a/webcomponent/download-openapi-jar.sh
+++ b/webcomponent/download-openapi-jar.sh
@@ -7,7 +7,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 echo "Starting download script ..."
 
 echo "----------------------------------------"
-echo "Project: $SCRIPT_DIR"
 
 # Reading version number of openapi-config file
 CFG="$SCRIPT_DIR/openapitools.json"
@@ -25,7 +24,7 @@ if [ -z "${VER:-}" ]; then
   exit 1
 fi
 
-echo " => Selected version in config-file: $VER"
+echo "Selected version in config-file: $VER"
 
 # Remote filename and location of jar
 REMOTE_JAR="openapi-generator-cli-$VER.jar"
@@ -37,7 +36,7 @@ mkdir -p "$DIR"
 
 # Check if jar file already exists
 if [ -f "$DIR/$LOCAL_JAR" ]; then
-  echo " => .jar file already exists: $DIR/$LOCAL_JAR, skipping download."
+  echo ".jar file already exists: $DIR/$LOCAL_JAR, skipping download."
   echo "----------------------------------------"
   echo "Done ..."
   exit 0
@@ -49,12 +48,12 @@ if ! command -v mvn > /dev/null 2>&1; then
   exit 1
 fi
 
-echo " => Downloading .jar file using Maven:"
-echo "    Target-file: $DIR/$LOCAL_JAR"
+echo "Downloading .jar file using Maven..."
 
-mvn dependency:copy "-Dartifact=org.openapitools:openapi-generator-cli:$VER:jar" "-DoutputDirectory=$DIR"
+mvn dependency:copy "-Dartifact=org.openapitools:openapi-generator-cli:$VER:jar" "-DoutputDirectory=$DIR" 1>/dev/null
 mv "$DIR/$REMOTE_JAR" "$DIR/$LOCAL_JAR"
 
-echo " => Download completed"
+echo "Download completed"
+echo "File downloaded to $DIR/$LOCAL_JAR"
 echo "----------------------------------------"
 echo "Done ..."


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Refactored download of `.jar` file to use Maven instead of wget and curl
- Added checks for `mvn` and `bash` availability

## Reference

Issue: internal node registry

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Opened documentation issue in [refarch repository][refarch-create-documentation-issue-link] (if applicable)

### Code

- [x] Wrote code and comments in English

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated OpenAPI Generator CLI JAR download to use Maven dependency resolution (then place the versioned JAR locally).
  * Removed build-script handling of npm proxy settings; configure Maven settings separately when needed.
  * Improved console output to focus on the target JAR path when downloads are skipped/completed.
  * Added pre-flight checks for required tooling (Maven for the download script, Bash for the batch wrapper).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->