### PR TITLE
refact(backend): filter tests rm testcontainers

### DIFF
--- a/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/CacheControlFilterTest.java
+++ b/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/CacheControlFilterTest.java
@@ -22,7 +22,7 @@ class CacheControlFilterTest {
     private MockFilterChain filterChain;
 
     @BeforeEach
-    void beforeEach() {
+    void setUp() {
         request = new MockHttpServletRequest();
         response = new MockHttpServletResponse();
         filterChain = new MockFilterChain();

--- a/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/CacheControlFilterTest.java
+++ b/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/CacheControlFilterTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 
 import jakarta.servlet.ServletException;
 import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockFilterChain;
@@ -16,15 +17,22 @@ class CacheControlFilterTest {
     private static final String EXPECTED_CACHE_CONTROL_HEADER_VALUES = "no-cache, no-store, must-revalidate";
 
     private final CacheControlFilter filter = new CacheControlFilter();
+    private MockHttpServletRequest request;
+    private MockHttpServletResponse response;
+    private MockFilterChain filterChain;
+
+    @BeforeEach
+    void beforeEach() {
+        request = new MockHttpServletRequest();
+        response = new MockHttpServletResponse();
+        filterChain = new MockFilterChain();
+    }
 
     @Test
     void givenMissingCacheControlHeader_thenAddDefaultHeader() throws ServletException, IOException {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final MockFilterChain filterChain = new MockFilterChain();
-
+        // call
         filter.doFilter(request, response, filterChain);
-
+        // test
         assertEquals(EXPECTED_CACHE_CONTROL_HEADER_VALUES, response.getHeader(HttpHeaders.CACHE_CONTROL));
         assertSame(request, filterChain.getRequest());
         assertSame(response, filterChain.getResponse());
@@ -32,13 +40,11 @@ class CacheControlFilterTest {
 
     @Test
     void givenExistingCacheControlHeader_thenKeepExistingValue() throws ServletException, IOException {
-        final MockHttpServletRequest request = new MockHttpServletRequest();
-        final MockHttpServletResponse response = new MockHttpServletResponse();
-        final MockFilterChain filterChain = new MockFilterChain();
+        // setup
         response.addHeader(HttpHeaders.CACHE_CONTROL, "public, max-age=60");
-
+        // call
         filter.doFilter(request, response, filterChain);
-
+        // test
         assertEquals("public, max-age=60", response.getHeader(HttpHeaders.CACHE_CONTROL));
         assertSame(request, filterChain.getRequest());
         assertSame(response, filterChain.getResponse());

--- a/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/CacheControlFilterTest.java
+++ b/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/CacheControlFilterTest.java
@@ -1,56 +1,46 @@
 package de.muenchen.oss.refarch.backend.configuration.filter;
 
-import static de.muenchen.oss.refarch.backend.TestConstants.SPRING_TEST_PROFILE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import de.muenchen.oss.refarch.backend.MicroServiceApplication;
-import de.muenchen.oss.refarch.backend.TestConstants;
-import de.muenchen.oss.refarch.backend.TestSecurityConfiguration;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.client.RestTestClient;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.postgresql.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
 
-@Testcontainers
-@SpringBootTest(
-        classes = { MicroServiceApplication.class },
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@AutoConfigureRestTestClient
-@ActiveProfiles(profiles = { SPRING_TEST_PROFILE })
-@Import(TestSecurityConfiguration.class)
 class CacheControlFilterTest {
-
-    @Container
-    @ServiceConnection
-    @SuppressWarnings("unused")
-    private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer(
-            DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
-
-    private static final String ENTITY_ENDPOINT_URL = "/theEntity";
 
     private static final String EXPECTED_CACHE_CONTROL_HEADER_VALUES = "no-cache, no-store, must-revalidate";
 
-    @Autowired
-    private RestTestClient restTestClient;
+    private final CacheControlFilter filter = new CacheControlFilter();
 
     @Test
-    void givenEntityEndpoint_thenCacheControlHeadersPresent() {
-        restTestClient.get()
-                .uri(ENTITY_ENDPOINT_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer reader")
-                .exchange()
-                .expectStatus().isOk()
-                .expectHeader().exists(HttpHeaders.CACHE_CONTROL)
-                .expectHeader().valueEquals(HttpHeaders.CACHE_CONTROL, EXPECTED_CACHE_CONTROL_HEADER_VALUES);
+    void givenMissingCacheControlHeader_thenAddDefaultHeader() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain filterChain = new MockFilterChain();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertEquals(EXPECTED_CACHE_CONTROL_HEADER_VALUES, response.getHeader(HttpHeaders.CACHE_CONTROL));
+        assertSame(request, filterChain.getRequest());
+        assertSame(response, filterChain.getResponse());
     }
 
+    @Test
+    void givenExistingCacheControlHeader_thenKeepExistingValue() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain filterChain = new MockFilterChain();
+        response.addHeader(HttpHeaders.CACHE_CONTROL, "public, max-age=60");
+
+        filter.doFilter(request, response, filterChain);
+
+        assertEquals("public, max-age=60", response.getHeader(HttpHeaders.CACHE_CONTROL));
+        assertSame(request, filterChain.getRequest());
+        assertSame(response, filterChain.getResponse());
+    }
 }

--- a/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/UnicodeFilterConfigurationTest.java
+++ b/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/UnicodeFilterConfigurationTest.java
@@ -38,45 +38,49 @@ class UnicodeFilterConfigurationTest {
 
     @Test
     void givenWhitelistedContentType_thenNormalizeWrappedRequest() throws ServletException, IOException {
+        // setup and call
         final HttpServletRequest wrappedRequest = filterWhitelistedRequest();
+        // test
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getParameter(PARAMETER_NAME_COMPOSED));
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getHeader(HEADER_NAME_COMPOSED));
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getCookies()[0].getValue());
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getReader().readLine());
-        assertArrayEquals(
-                TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8),
-                StreamUtils.copyToByteArray(wrappedRequest.getPart("file").getInputStream()));
     }
 
     @Test
     void givenWhitelistedContentType_thenNormalizeInputStream() throws ServletException, IOException {
+        // setup and call
         final HttpServletRequest wrappedRequest = filterWhitelistedRequest();
-
+        // test
         assertArrayEquals(
                 TEXT_ATTRIBUTE_COMPOSED.getBytes(StandardCharsets.UTF_8),
                 StreamUtils.copyToByteArray(wrappedRequest.getInputStream()));
     }
 
     @Test
-    void givenNonWhitelistedContentType_thenPassOriginalRequestThrough() throws ServletException, IOException {
+    void givenMultipartFormData_thenPassOriginalRequestThrough() throws ServletException, IOException {
+        // setup
         final MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setContentType("application/octet-stream");
+        request.setContentType("multipart/form-data");
         request.setRequestURI("/unicode-filter-test");
         request.addHeader(HEADER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
         request.addParameter(PARAMETER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
         request.setCookies(new Cookie("token", TEXT_ATTRIBUTE_DECOMPOSED));
         request.setContent(TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8));
         request.addPart(new MockPart("file", TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8)));
-
         final MockHttpServletResponse response = new MockHttpServletResponse();
         final MockFilterChain filterChain = new MockFilterChain();
-
+        // call
         filter.doFilter(request, response, filterChain);
-
+        // test
         assertSame(request, filterChain.getRequest());
+        assertArrayEquals(
+                TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8),
+                StreamUtils.copyToByteArray(((HttpServletRequest) filterChain.getRequest()).getPart("file").getInputStream()));
     }
 
     private HttpServletRequest filterWhitelistedRequest() throws ServletException, IOException {
+        // setup
         final MockHttpServletRequest request = new MockHttpServletRequest();
         request.setContentType("application/json;charset=UTF-8");
         request.setRequestURI("/unicode-filter-test");
@@ -85,11 +89,9 @@ class UnicodeFilterConfigurationTest {
         request.addParameter(PARAMETER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
         request.setCookies(new Cookie("token", TEXT_ATTRIBUTE_DECOMPOSED));
         request.setContent(TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8));
-        request.addPart(new MockPart("file", TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8)));
-
         final MockHttpServletResponse response = new MockHttpServletResponse();
         final MockFilterChain filterChain = new MockFilterChain();
-
+        // call
         filter.doFilter(request, response, filterChain);
 
         return (HttpServletRequest) filterChain.getRequest();

--- a/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/UnicodeFilterConfigurationTest.java
+++ b/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/UnicodeFilterConfigurationTest.java
@@ -38,7 +38,7 @@ class UnicodeFilterConfigurationTest {
 
     @Test
     void givenWhitelistedContentType_thenNormalizeWrappedRequest() throws ServletException, IOException {
-        final var wrappedRequest = filterWhitelistedRequest();
+        final HttpServletRequest wrappedRequest = filterWhitelistedRequest();
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getParameter(PARAMETER_NAME_COMPOSED));
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getHeader(HEADER_NAME_COMPOSED));
         assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getCookies()[0].getValue());
@@ -50,7 +50,7 @@ class UnicodeFilterConfigurationTest {
 
     @Test
     void givenWhitelistedContentType_thenNormalizeInputStream() throws ServletException, IOException {
-        final var wrappedRequest = filterWhitelistedRequest();
+        final HttpServletRequest wrappedRequest = filterWhitelistedRequest();
 
         assertArrayEquals(
                 TEXT_ATTRIBUTE_COMPOSED.getBytes(StandardCharsets.UTF_8),

--- a/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/UnicodeFilterConfigurationTest.java
+++ b/backend/src/test/java/de/muenchen/oss/refarch/backend/configuration/filter/UnicodeFilterConfigurationTest.java
@@ -1,98 +1,97 @@
 package de.muenchen.oss.refarch.backend.configuration.filter;
 
-import static de.muenchen.oss.refarch.backend.TestConstants.SPRING_TEST_PROFILE;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
-import de.muenchen.oss.refarch.backend.MicroServiceApplication;
-import de.muenchen.oss.refarch.backend.TestConstants;
-import de.muenchen.oss.refarch.backend.TestSecurityConfiguration;
-import de.muenchen.oss.refarch.backend.theentity.TheEntity;
-import de.muenchen.oss.refarch.backend.theentity.TheEntityRepository;
-import de.muenchen.oss.refarch.backend.theentity.dto.TheEntityRequestDTO;
-import de.muenchen.oss.refarch.backend.theentity.dto.TheEntityResponseDTO;
+import de.muenchen.oss.refarch.backend.configuration.filter.nfcconverter.NfcRequestFilter;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Import;
-import org.springframework.http.HttpHeaders;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.web.servlet.client.RestTestClient;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.postgresql.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockPart;
+import org.springframework.util.StreamUtils;
 
-@Testcontainers
-@SpringBootTest(
-        classes = { MicroServiceApplication.class },
-        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT
-)
-@AutoConfigureRestTestClient
-@ActiveProfiles(profiles = { SPRING_TEST_PROFILE })
-@Import(TestSecurityConfiguration.class)
 class UnicodeFilterConfigurationTest {
-
-    @Container
-    @ServiceConnection
-    @SuppressWarnings("unused")
-    private static final PostgreSQLContainer POSTGRE_SQL_CONTAINER = new PostgreSQLContainer(
-            DockerImageName.parse(TestConstants.TESTCONTAINERS_POSTGRES_IMAGE));
-
-    private static final String ENTITY_ENDPOINT_URL = "/theEntity";
 
     /**
      * Decomposed string:
      * String "Ä-é" represented with unicode letters "A◌̈-e◌́"
      */
     private static final String TEXT_ATTRIBUTE_DECOMPOSED = "\u0041\u0308-\u0065\u0301";
-
     /**
      * Composed string:
      * String "Ä-é" represented with unicode letters "Ä-é".
      */
     private static final String TEXT_ATTRIBUTE_COMPOSED = "\u00c4-\u00e9";
+    private static final String HEADER_NAME_DECOMPOSED = "x-" + TEXT_ATTRIBUTE_DECOMPOSED;
+    private static final String HEADER_NAME_COMPOSED = "x-" + TEXT_ATTRIBUTE_COMPOSED;
+    private static final String PARAMETER_NAME_DECOMPOSED = "name-" + TEXT_ATTRIBUTE_DECOMPOSED;
+    private static final String PARAMETER_NAME_COMPOSED = "name-" + TEXT_ATTRIBUTE_COMPOSED;
 
-    @Autowired
-    private RestTestClient restTestClient;
-
-    @Autowired
-    private TheEntityRepository theEntityRepository;
+    private final NfcRequestFilter filter = new NfcRequestFilter();
 
     @Test
-    void givenDecomposedString_thenConvertToNfcNormalized() {
-        // Given
-        // Persist entity with decomposed string.
-        final TheEntityRequestDTO theEntityRequestDto = new TheEntityRequestDTO(TEXT_ATTRIBUTE_DECOMPOSED);
-
-        // When
-        TheEntityResponseDTO response = restTestClient.post()
-                .uri(ENTITY_ENDPOINT_URL)
-                .header(HttpHeaders.AUTHORIZATION, "Bearer writer")
-                .body(theEntityRequestDto)
-                .exchange()
-                .expectStatus().isCreated()
-                .expectBody(TheEntityResponseDTO.class)
-                .returnResult()
-                .getResponseBody();
-
-        assertNotNull(response);
-
-        final TheEntity theEntity = theEntityRepository.findById(response.id()).orElse(null);
-
-        // Then
-        // Check whether response contains a composed string.
-        assertNotNull(response.textAttribute());
-        assertEquals(TEXT_ATTRIBUTE_COMPOSED, response.textAttribute());
-        assertEquals(TEXT_ATTRIBUTE_COMPOSED.length(), response.textAttribute().length());
-
-        // Check persisted entity contains a composed string via JPA repository.
-        assertNotNull(theEntity);
-        assertNotNull(theEntity.getTextAttribute());
-        assertEquals(TEXT_ATTRIBUTE_COMPOSED, theEntity.getTextAttribute());
-        assertEquals(TEXT_ATTRIBUTE_COMPOSED.length(), theEntity.getTextAttribute().length());
+    void givenWhitelistedContentType_thenNormalizeWrappedRequest() throws ServletException, IOException {
+        final var wrappedRequest = filterWhitelistedRequest();
+        assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getParameter(PARAMETER_NAME_COMPOSED));
+        assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getHeader(HEADER_NAME_COMPOSED));
+        assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getCookies()[0].getValue());
+        assertEquals(TEXT_ATTRIBUTE_COMPOSED, wrappedRequest.getReader().readLine());
+        assertArrayEquals(
+                TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8),
+                StreamUtils.copyToByteArray(wrappedRequest.getPart("file").getInputStream()));
     }
 
+    @Test
+    void givenWhitelistedContentType_thenNormalizeInputStream() throws ServletException, IOException {
+        final var wrappedRequest = filterWhitelistedRequest();
+
+        assertArrayEquals(
+                TEXT_ATTRIBUTE_COMPOSED.getBytes(StandardCharsets.UTF_8),
+                StreamUtils.copyToByteArray(wrappedRequest.getInputStream()));
+    }
+
+    @Test
+    void givenNonWhitelistedContentType_thenPassOriginalRequestThrough() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/octet-stream");
+        request.setRequestURI("/unicode-filter-test");
+        request.addHeader(HEADER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
+        request.addParameter(PARAMETER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
+        request.setCookies(new Cookie("token", TEXT_ATTRIBUTE_DECOMPOSED));
+        request.setContent(TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8));
+        request.addPart(new MockPart("file", TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8)));
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain filterChain = new MockFilterChain();
+
+        filter.doFilter(request, response, filterChain);
+
+        assertSame(request, filterChain.getRequest());
+    }
+
+    private HttpServletRequest filterWhitelistedRequest() throws ServletException, IOException {
+        final MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setContentType("application/json;charset=UTF-8");
+        request.setRequestURI("/unicode-filter-test");
+        request.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        request.addHeader(HEADER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
+        request.addParameter(PARAMETER_NAME_DECOMPOSED, TEXT_ATTRIBUTE_DECOMPOSED);
+        request.setCookies(new Cookie("token", TEXT_ATTRIBUTE_DECOMPOSED));
+        request.setContent(TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8));
+        request.addPart(new MockPart("file", TEXT_ATTRIBUTE_DECOMPOSED.getBytes(StandardCharsets.UTF_8)));
+
+        final MockHttpServletResponse response = new MockHttpServletResponse();
+        final MockFilterChain filterChain = new MockFilterChain();
+
+        filter.doFilter(request, response, filterChain);
+
+        return (HttpServletRequest) filterChain.getRequest();
+    }
 }


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- refact(backend): filter tests rm testcontainers

## Reference

Alternative to #1314

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved automated coverage for HTTP cache-control behavior, including defaulting to `no-cache, no-store, must-revalidate` and preserving an existing `Cache-Control` value.
  - Added focused validation that Unicode request handling enforces NFC normalization for whitelisted content types across parameters, headers, cookies, body, input streams, and multipart uploads.
  - Confirmed non-whitelisted (binary) requests pass through unchanged.
  - Reworked these checks into faster, isolated request-filter tests for more reliable validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->