### PR TITLE
:wrench: Changed to architecture agnostic SHA pins in Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,6 @@
 # Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
 
-# For documentation see https://jboss-container-images.github.io/openjdk/
+# For documentation see https://rh-openjdk.github.io/redhat-openjdk-containers/
 FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
 # Copy runnable jar to deployments

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # For documentation see https://jboss-container-images.github.io/openjdk/
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:0adb5132beb506b62fc15d86619a761868003506e0e2b5b6ca9ba82be519ca64
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
 # Copy runnable jar to deployments
 COPY target/*.jar /deployments/application.jar

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,5 @@
+# Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
+
 # For documentation see https://jboss-container-images.github.io/openjdk/
 FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 

--- a/eai/Dockerfile
+++ b/eai/Dockerfile
@@ -1,6 +1,6 @@
 # Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
 
-# For documentation see https://jboss-container-images.github.io/openjdk/
+# For documentation see https://rh-openjdk.github.io/redhat-openjdk-containers/
 FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
 # Copy runnable jar to deployments

--- a/eai/Dockerfile
+++ b/eai/Dockerfile
@@ -1,5 +1,5 @@
 # For documentation see https://jboss-container-images.github.io/openjdk/
-FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:0adb5132beb506b62fc15d86619a761868003506e0e2b5b6ca9ba82be519ca64
+FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 
 # Copy runnable jar to deployments
 COPY target/*.jar /deployments/application.jar

--- a/eai/Dockerfile
+++ b/eai/Dockerfile
@@ -1,3 +1,5 @@
+# Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
+
 # For documentation see https://jboss-container-images.github.io/openjdk/
 FROM registry.access.redhat.com/ubi10/openjdk-21-runtime:1.24-11@sha256:2056c5139666c5e52f01af5b80f0def423a94c3fe824321d74041c11e20c9b72
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,3 +1,5 @@
+# Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
+
 # For documentation see https://github.com/sclorg/nginx-container
 FROM registry.access.redhat.com/ubi10/nginx-126:10.2-1785834614@sha256:7d6db4671f89ee84e1a28f5902f84ff7ef8128e6acc2991fd07f43cbf68eed25
 

--- a/webcomponent/Dockerfile
+++ b/webcomponent/Dockerfile
@@ -1,3 +1,5 @@
+# Note: For base images an architecture-agnostic SHA is always preferred, see https://refarch.oss.muenchen.de/templates/deploy.html#docker-images for more info.
+
 # For documentation see https://github.com/sclorg/nginx-container
 FROM registry.access.redhat.com/ubi10/nginx-126:10.2-1785834614@sha256:7d6db4671f89ee84e1a28f5902f84ff7ef8128e6acc2991fd07f43cbf68eed25
 


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Changed to architecture agnostic SHA pins (identified via `docker buildx imagetools inspect <image_without_sha>`

## Reference

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Opened follow-up issue in [refarch repository](https://github.com/it-at-m/refarch/pull/991)

### Development Stack

- [x] Checked functionality of Docker stack (if Docker stack was modified or images were changed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated container runtime images to newer pinned versions.
  - Improved Docker base-image guidance for compatibility across CPU architectures.
  - Updated OpenJDK documentation references.
  - Added deployment guidance for selecting architecture-agnostic image digests.
  - Applied consistent image-reference guidance across backend, EAI, frontend, and web component containers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->