### PR TITLE
:sparkles: Added multiarchitecture build for amd64 and arm64 by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,9 +68,10 @@ jobs:
         uses: it-at-m/lhm_actions/action-templates/actions/action-build-image@bcd2cb2a470e6de82ba45ce9ede3d2f43560c58a # v1.5.0
         with:
           path: ${{ matrix.app-path }}
-          image-name: ${{ matrix.app-path }}
           artifact-name: ${{ join(steps.*.outputs.artifact-name) }}
-          registry-password: ${{ secrets.GITHUB_TOKEN }}
-          registry-username: ${{ github.actor }}
+          image-name: ${{ matrix.app-path }}
           image-tags: |
             type=raw,value=dev
+          platforms: "linux/amd64,linux/arm64"
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          registry-username: ${{ github.actor }}

--- a/.github/workflows/release-maven.yml
+++ b/.github/workflows/release-maven.yml
@@ -59,6 +59,7 @@ jobs:
           image-tags: |
             type=semver,pattern={{version}},value=${{ inputs.release-version }}
             type=raw,value=latest
+          platforms: "linux/amd64,linux/arm64"
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -58,13 +58,14 @@ jobs:
       - uses: it-at-m/lhm_actions/action-templates/actions/action-build-image@bcd2cb2a470e6de82ba45ce9ede3d2f43560c58a # v1.5.0
         with:
           path: ${{ inputs.app-path }}
-          image-name: ${{ inputs.app-path }}
           artifact-name: ${{ needs.release-npm-artifact.outputs.ARTIFACT_NAME }}
-          registry-password: ${{ secrets.GITHUB_TOKEN }}
-          registry-username: ${{ github.actor }}
+          image-name: ${{ inputs.app-path }}
           image-tags: |
             type=semver,pattern={{version}},value=${{ needs.release-npm-artifact.outputs.ARTIFACT_VERSION }}
             type=raw,value=latest
+          platforms: "linux/amd64,linux/arm64"
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+          registry-username: ${{ github.actor }}
 
   release-npm-github:
     needs: release-npm-artifact


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml


closes https://github.com/it-at-m/lhm_actions/issues/318

## Changes

- Added multiarchitecture image builds for AMD64 and ARM64

## Checklist

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [x] Opened documentation issue in [refarch repository](https://github.com/it-at-m/refarch/pull/998)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now built for both `linux/amd64` and `linux/arm64` platforms.
  * Maven and npm release images support the same multi-platform architecture coverage.
* **Chores**
  * Streamlined image build configuration while preserving existing tagging and registry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->