### PR TITLE
Fix ApiFactory failing on Chrome browsers

### DIFF
--- a/frontend/src/api/ApiFactory.ts
+++ b/frontend/src/api/ApiFactory.ts
@@ -1,5 +1,3 @@
-import type { HTTPHeaders } from "@/api/generated/refarch-backend";
-
 import { getHeaders } from "@/api/fetch-utils.ts";
 import { BaseAPI, Configuration } from "@/api/generated/refarch-backend";
 import { BASE_API_PATH } from "@/constants.ts";
@@ -26,12 +24,11 @@ function createConfig(): Configuration {
     middleware: [
       {
         pre: async (context) => {
-          const freshHeaders = convertHeaders(getHeaders());
           return {
             url: context.url,
             init: {
               ...context.init,
-              headers: { ...context.init.headers, ...freshHeaders },
+              headers: mergeHeaders(context.init.headers, getHeaders()),
             },
           };
         },
@@ -57,16 +54,18 @@ function getInstance<T extends BaseAPI>(ApiClass: ApiCtor<T>): T {
 }
 
 /**
- * Converts a Headers object into a simple key-value pair object.
- * @param {Headers} headers - The headers object to be converted.
- * @returns {HTTPHeaders} An object with the same headers.
+ * Merging happens via the Headers API because HTTP header names are case-insensitive. The generated
+ * client writes "Content-Type" while {@link getHeaders} yields lowercase names, so a plain object
+ * spread would keep both keys. Fetch would then send them as one invalid header value
+ * "application/json, application/json" in Chrome browsers.
  */
-function convertHeaders(headers: Headers): HTTPHeaders {
-  const httpHeaders: HTTPHeaders = {};
-  headers.forEach((value, key) => {
-    httpHeaders[key] = value;
-  });
-  return httpHeaders;
+function mergeHeaders(
+  defaults: HeadersInit | undefined,
+  headers: Headers,
+): Headers {
+  const merged = new Headers(defaults);
+  new Headers(headers).forEach((value, key) => merged.set(key, value));
+  return merged;
 }
 
 export const ApiFactory = {


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Merges the HTTP headers in ApiFactory.ts case-insensitive. 

When using a Chrome browser and sending a json payload, the backend responds with a 415. See https://github.com/mariusgau/refarch-templates/commit/316ec831db53f4d9bba085df2da9e09f9e33a9b8 in https://github.com/mariusgau/refarch-templates/tree/test/provoke-415 to reproduce the error.

## Reference

Issue: #XXX

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [ ] ~~I have read the Contribution Guidelines (TBD)~~
- [ ] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description
- [ ] Opened documentation issue in [refarch repository][refarch-create-documentation-issue-link] (if applicable)
- [ ] Opened follow-up issue in [refarch repository][refarch-create-issue-link] (if applicable)

### Code

- [x] Wrote code and comments in English
- [ ] Added unit tests
- [x] Removed waste on branch (e.g. `console.log`), see [code quality tooling][code-quality-link]

#### Backend / EAI

- [ ] Added integration tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request header handling to ensure headers are merged consistently, regardless of capitalization.
  * Prevented existing request headers from being unintentionally overwritten during configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->