### PR TITLE
:fire: Get rid of custom CSS classes

### DIFF
--- a/frontend/src/routes/index.vue
+++ b/frontend/src/routes/index.vue
@@ -21,11 +21,11 @@
         </h1>
         <p>
           {{ t("views.index.apiGatewayStatus") }}
-          <span :class="apiGwStatus">{{ apiGwStatus }}</span>
+          <span :class="statusColor(apiGwStatus)">{{ apiGwStatus }}</span>
         </p>
         <p>
           {{ t("views.index.backendStatus") }}
-          <span :class="backendStatus">{{ backendStatus }}</span>
+          <span :class="statusColor(backendStatus)">{{ backendStatus }}</span>
         </p>
       </v-col>
     </v-row>
@@ -77,14 +77,8 @@ onMounted(async () => {
     });
   }
 });
+
+function statusColor(status: string) {
+  return status === "UP" ? "text-success" : "text-error";
+}
 </script>
-
-<style scoped>
-.UP {
-  color: limegreen;
-}
-
-.DOWN {
-  color: lightcoral;
-}
-</style>

--- a/webcomponent/src/refarch-hello-world-webcomponent.ce.vue
+++ b/webcomponent/src/refarch-hello-world-webcomponent.ce.vue
@@ -12,11 +12,15 @@
         <p>{{ calloutContent }}</p>
         <p>
           Das API-Gateway ist:
-          <span :class="apiGwStatus">{{ apiGwStatus }}</span>
+          <span :style="{ color: statusColor(apiGwStatus) }">{{
+            apiGwStatus
+          }}</span>
         </p>
         <p>
           Das Backend ist:
-          <span :class="backendStatus">{{ backendStatus }}</span>
+          <span :style="{ color: statusColor(backendStatus) }">{{
+            backendStatus
+          }}</span>
         </p>
       </template>
     </muc-callout>
@@ -54,18 +58,14 @@ onMounted(async () => {
   const contentBackend = await ApiFactory.getInstance(ActuatorApi).health();
   backendStatus.value = (contentBackend as HealthState).status;
 });
+
+function statusColor(status: string) {
+  return status === "UP" ? "limegreen" : "lightcoral";
+}
 </script>
 
 <style>
 @import url("https://assets.muenchen.de/mde/1.1.23/css/style.css");
 @import "@muenchen/muc-patternlab-vue/assets/css/custom-style.css";
 @import "@muenchen/muc-patternlab-vue/style.css";
-
-.UP {
-  color: limegreen;
-}
-
-.DOWN {
-  color: lightcoral;
-}
 </style>


### PR DESCRIPTION
# Pull Request

<!-- Links -->
[code-quality-link]: https://refarch.oss.muenchen.de/templates/develop#code-quality
[refarch-create-issue-link]: https://github.com/it-at-m/refarch/issues/new/choose
[refarch-create-documentation-issue-link]: https://github.com/it-at-m/refarch/issues/new?template=4-documentation-change.yml

## Changes

- Removed custom CSS classes for `up` and `down` state of Gateway/Backend in Frontend + Webcomponent Template

## Reference

Closes #76

## Checklist

**Note**: If some checklist items are not relevant for your PR, just remove them.

### General

- [x] Met all acceptance criteria of the issue
- [x] Added meaningful PR title and list of changes in the description

### Code

- [x] Wrote code and comments in English
- [x] Removed waste on branch (e.g. `console.log`), see [code quality tooling][code-quality-link]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved status indicators with consistent color coding.
  * Successful “UP” statuses display in green, while other statuses display in red or coral.
  * Simplified status styling across the application and web component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->